### PR TITLE
Force add docs/ and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ inst/doc
 .DS_Store
 .vscode
 tests/testthat/tic
+docs/

--- a/R/steps-git.R
+++ b/R/steps-git.R
@@ -258,13 +258,15 @@ DoPushDeploy <- R6Class(
 
     commit = function() {
       message("Staging: ", paste(private$commit_paths, collapse = ", "))
-      git2r::add(private$git$get_repo(), private$commit_paths)
+      git2r::add(private$git$get_repo(), private$commit_paths, force = TRUE)
 
       message("Checking changed files")
       status <- git2r::status(
         private$git$get_repo(),
         staged = TRUE,
-        unstaged = FALSE, untracked = FALSE, ignored = FALSE
+        unstaged = FALSE,
+        untracked = FALSE,
+        ignored = FALSE
       )
       if (length(status$staged) == 0) {
         message("Nothing to commit!")

--- a/R/use_tic.R
+++ b/R/use_tic.R
@@ -412,6 +412,10 @@ use_tic_r <- function(repo_type, deploy_on = "none") {
   cli_end()
   cli_h2("tic.R")
 
+  # if deploy is requested, we most likely build a pkgdown site and should
+  # ignore "docs/" here
+  usethis::use_git_ignore("docs/")
+
   if (repo_type == "unknown") {
     use_tic_template(file.path(
       repo_type,


### PR DESCRIPTION
I am always annoyed by having local artifacts of a local pkgdown build around in the git index.
So far we could not add it to `.gitignore` because {tic} would have ignored the built files during staging.

We now force add files and should be safe ignoring `docs/`. 