### PR TITLE
Refactor `use_badge()`

### DIFF
--- a/R/use-badge.R
+++ b/R/use-badge.R
@@ -1,74 +1,48 @@
 #' Add a CI Status Badge to README
 #'
 #' @description
-#'  Adds a CI status badge generated via \url{https://shields.io/} to
-#'  `README.Rmd` or `README.md`. By default the label `"R CMD Check via {tic}"`
-#'  will be used. By setting `type = "logo`, a logo of the respective CI
-#'  provider will be used instead.
+#'  Adds a CI status badge `README.Rmd` or `README.md`. By default the label is
+#'  `"R CMD Check via {tic}".
 #'
-#'  A custom label can be provided via argument `label`.
+#'  A custom branch can be specified via argument `branch`.
 #'
 #' @param provider `character(1)`\cr
 #'   The CI provider to generate a badge for. Only `ghactions` is currently
 #'   supported
-#' @param logo `logical(1)`\cr
-#'   Should a logo of the respective CI provider be used?
+#' @param branch `character(1)`\cr
+#'   Which branch should the badge represent?
 #' @param label `character(1)`\cr
-#'   Text to use for the badge. To use no label, set `label = NULL`.
+#'   Text to use for the badge.
 #'
-#' @export
 #' @examples
 #' \dontrun{
 #' use_tic_badge(provider = "ghactions")
 #'
-#' # no logo, only label
-#' use_tic_badge(provider = "ghactions", logo = FALSE)
-#'
-#' # no label, only logo
-#' use_tic_badge(provider = "ghactions", label = NULL)
+#' # use a different branch
+#' use_tic_badge(provider = "ghactions", branch = "develop")
 #' }
+#' @export
 use_tic_badge <- function(provider,
-                          logo = TRUE,
+                          branch = "master",
                           label = "R CMD Check via {tic}") {
 
   requireNamespace("usethis", quietly = TRUE)
 
-  if (provider == "ghactions") {
-    if (logo) {
-      logo <- "logo=github"
-    } else {
-      logo <- NULL
-    }
+  label_badge <- label
+  # whitespaces do not render in README.md files
+  label_badge <- gsub(" ", "%20", label_badge)
 
-    if (!is.null(label)) {
-      label_badge <- paste0("label=", label)
-      # whitespaces do not render in README.md files
-      label_badge <- gsub(" ", "%20", label_badge)
-    } else {
-      label_badge <- NULL
-    }
+  github_home <- paste0("https://github.com/", ci_get_slug())
+  url <- paste0(github_home, "/actions")
+  img <- paste0(
+    github_home,
+    "/workflows/",
+    label_badge,
+    "/badge.svg",
+    "?branch=",
+    branch
+  )
 
-    # melt them if both are provided
-    if (!is.null(label_badge) && is.character(logo)) {
-      badge_style <- paste0(logo, "&", label_badge)
-    } else {
-      badge_style <- paste0(logo, label_badge)
-    }
-
-    github_home <- paste0("https://github.com/", ci_get_slug())
-    url <- paste0(github_home, "/actions")
-    img <- paste0(
-      "https://img.shields.io/github/workflow/status/",
-      ci_get_slug(), "/R%20CMD%20Check%20via%20%7Btic%7D?",
-      badge_style,
-      "&style=flat-square"
-    )
-
-    # in case label = NULL
-    if (is.null(label)) {
-      label <- "build status"
-    }
-  }
   catch <- tryCatch(
     # suppressing "Multiple github remotes found. Using origin."
     # the git remote cannot be set anyways

--- a/R/use-badge.R
+++ b/R/use-badge.R
@@ -1,8 +1,8 @@
-#' Add a CI Status Badge to README
+#' Add a CI Status Badge to README files
 #'
 #' @description
-#'  Adds a CI status badge `README.Rmd` or `README.md`. By default the label is
-#'  `"R CMD Check via {tic}".
+#'  Adds a CI status badge to `README.Rmd` or `README.md`. By default the label
+#'  is `"R CMD Check via {tic}".
 #'
 #'  A custom branch can be specified via argument `branch`.
 #'

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # tic
 
 <!-- badges: start -->
-
-[![R CMD Check via
-{tic}](https://img.shields.io/github/workflow/status/ropensci/tic/R%20CMD%20Check%20via%20%7Btic%7D?logo=github&label=R%20CMD%20Check%20via%20%7Btic%7D&style=flat-square)](https://github.com/ropensci/tic/actions)
+[![R CMD Check via {tic}](https://github.com/ropensci/tic/workflows/R%20CMD%20Check%20via%20{tic}/badge.svg?branch=master)](https://github.com/ropensci/tic/actions)
 [![Travis build status](https://img.shields.io/travis/ropensci/tic/master?logo=travis&style=flat-square&label=Linux)](https://travis-ci.com/ropensci/tic)
 [![AppVeyor build status](https://img.shields.io/appveyor/ci/ropensci/tic?label=Windows&logo=appveyor&style=flat-square)](https://ci.appveyor.com/project/ropensci/tic)
 [![CircleCI](https://img.shields.io/circleci/build/gh/ropensci/tic/master?label=Linux&logo=circle&logoColor=green&style=flat-square)](https://circleci.com/gh/ropensci/tic)
@@ -11,7 +9,7 @@
 [![codecov](https://codecov.io/gh/ropensci/tic/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/tic)
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![](https://badges.ropensci.org/305_status.svg)](https://github.com/ropensci/software-review/issues/305)
-
+[![](https://github.com/user/repo/workflows//badge.svg?branch=master)](https://github.com/user/repo/actions)
 <!-- badges: end -->
 
 The goal of tic is to enhance and simplify working with continuous integration (CI) systems.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![codecov](https://codecov.io/gh/ropensci/tic/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/tic)
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![](https://badges.ropensci.org/305_status.svg)](https://github.com/ropensci/software-review/issues/305)
-[![](https://github.com/user/repo/workflows//badge.svg?branch=master)](https://github.com/user/repo/actions)
 <!-- badges: end -->
 
 The goal of tic is to enhance and simplify working with continuous integration (CI) systems.

--- a/man/use_tic_badge.Rd
+++ b/man/use_tic_badge.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/use-badge.R
 \name{use_tic_badge}
 \alias{use_tic_badge}
-\title{Add a CI Status Badge to README}
+\title{Add a CI Status Badge to README files}
 \usage{
 use_tic_badge(provider, branch = "master", label = "R CMD Check via {tic}")
 }
@@ -18,8 +18,8 @@ Which branch should the badge represent?}
 Text to use for the badge.}
 }
 \description{
-Adds a CI status badge \code{README.Rmd} or \code{README.md}. By default the label is
-`"R CMD Check via {tic}".
+Adds a CI status badge to \code{README.Rmd} or \code{README.md}. By default the label
+is `"R CMD Check via {tic}".
 
 A custom branch can be specified via argument \code{branch}.
 }

--- a/man/use_tic_badge.Rd
+++ b/man/use_tic_badge.Rd
@@ -4,35 +4,30 @@
 \alias{use_tic_badge}
 \title{Add a CI Status Badge to README}
 \usage{
-use_tic_badge(provider, logo = TRUE, label = "R CMD Check via {tic}")
+use_tic_badge(provider, branch = "master", label = "R CMD Check via {tic}")
 }
 \arguments{
 \item{provider}{\code{character(1)}\cr
 The CI provider to generate a badge for. Only \code{ghactions} is currently
 supported}
 
-\item{logo}{\code{logical(1)}\cr
-Should a logo of the respective CI provider be used?}
+\item{branch}{\code{character(1)}\cr
+Which branch should the badge represent?}
 
 \item{label}{\code{character(1)}\cr
-Text to use for the badge. To use no label, set \code{label = NULL}.}
+Text to use for the badge.}
 }
 \description{
-Adds a CI status badge generated via \url{https://shields.io/} to
-\code{README.Rmd} or \code{README.md}. By default the label \code{"R CMD Check via {tic}"}
-will be used. By setting \verb{type = "logo}, a logo of the respective CI
-provider will be used instead.
+Adds a CI status badge \code{README.Rmd} or \code{README.md}. By default the label is
+`"R CMD Check via {tic}".
 
-A custom label can be provided via argument \code{label}.
+A custom branch can be specified via argument \code{branch}.
 }
 \examples{
 \dontrun{
 use_tic_badge(provider = "ghactions")
 
-# no logo, only label
-use_tic_badge(provider = "ghactions", logo = FALSE)
-
-# no label, only logo
-use_tic_badge(provider = "ghactions", label = NULL)
+# use a different branch
+use_tic_badge(provider = "ghactions", branch = "develop")
 }
 }


### PR DESCRIPTION
Because shields.io is very slow and does not render correctly in some browsers (at least the GHA badge).

Now using the default one provided by GitHub.

Also beforehand all builds were taken into account for the badge status. Now we default to the master branch.