### PR TITLE
Adjust GH Actions templates to general `use_*_yml()` logic and use new R-devel toolchain on macOS

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,4 @@
 ^man-roxygen$
 ^\.github$
 ^clang-.*
+^gfortran.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         config:
           # comment out lines if you do not want to build on certain platforms
           - { os: windows-latest, r: "release" }
-          - { os: macOS-latest, r: "release" }
+          - { os: macOS-latest, r: "release", pkgdown: "true" }
           - { os: macOS-latest, r: "devel" }
           - { os: ubuntu-latest, r: "release" }
 
@@ -38,6 +38,11 @@ jobs:
       TIC_DEPLOY_KEY: ${{ secrets.TIC_DEPLOY_KEY }}
       # prevent rgl issues because no X11 display is available
       RGL_USE_NULL: true
+      # if you use bookdown or blogdown, replace "PKGDOWN" by the respective
+      # capitalized term. This also might need to be done in tic.R
+      BUILD_PKGDOWN: ${{ matrix.config.pkgdown }} 
+      # macOS >= 10.15.4 linking
+      SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 
     steps:
       - uses: actions/checkout@v2
@@ -91,7 +96,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt install ccache libcurl4-openssl-dev
-          mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache gcc -std=gnu99\nCXX=ccache g++\nCXX11=ccache g++ -std=gnu99\nCXX14=ccache g++ -std=gnu99\nC11=ccache g++\nC14=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
+          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
 
       # install ccache and write config file
       # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
@@ -101,8 +106,7 @@ jobs:
           brew install ccache
           wget https://cran.r-project.org/bin/macosx/tools/clang-7.0.0.pkg
           sudo installer -package clang-7.0.0.pkg -target /
-          mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache /usr/local/clang7/bin/clang\nCC11=ccache /usr/local/clang7/bin/clang\nCC14=ccache /usr/local/clang7/bin/clang\nCXX=ccache /usr/local/clang7/bin/clang++\nCXX11=ccache /usr/local/clang7/bin/clang++\nCXX14=ccache /usr/local/clang7/bin/clang++\nC11=ccache /usr/local/clang7/bin/clang++\nC14=ccache /usr/local/clang7/bin/clang++\nF77=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
-          R CMD javareconf
+          mkdir -p ~/.R && echo -e 'CC=ccache /usr/local/clang7/bin/clang\nCXX=ccache /usr/local/clang7/bin/clang++\nF77=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
 
       # install ccache and write config file
       # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
@@ -110,10 +114,19 @@ jobs:
         if: runner.os == 'macOS' && matrix.config.r == 'devel'
         run: |
           brew install ccache
-          wget https://cran.r-project.org/bin/macosx/tools/clang-8.0.0.pkg
-          sudo installer -package clang-8.0.0.pkg -target /
-          mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache /usr/local/clang8/bin/clang\nCC11=ccache /usr/local/clang8/bin/clang\nCC14=ccache /usr/local/clang8/bin/clang\nCXX=ccache /usr/local/clang8/bin/clang++\nCXX11=ccache /usr/local/clang8/bin/clang++\nCXX14=ccache /usr/local/clang8/bin/clang++\nC11=ccache /usr/local/clang8/bin/clang++\nC14=ccache /usr/local/clang8/bin/clang++\nF88=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
-          R CMD javareconf
+          # install SDK 10.13 (High Sierra, used by CRAN)
+          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
+          tar fxz MacOSX10.13.sdk.tar.xz
+          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
+          rm -rf MacOSX10.13*
+          # install gfortran 8.2 (used by CRAN)
+          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
+          sudo hdiutil attach gfortran*.dmg
+          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
+          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
+          rm gfortran-8*
+          # set compiler flags
+          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # for some strange Windows reason this step and the next one need to be decoupled
       - name: "[Stage] Prepare"
@@ -129,7 +142,7 @@ jobs:
       - name: "[Stage] Prepare & Install (macOS-devel)"
         if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
         run: |
-          echo -e 'options(pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
+          echo -e 'options(Ncpus = 4, pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
           Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
 
       - name: "[Stage] Script"
@@ -146,15 +159,12 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
       - name: "[Stage] Before Deploy"
-        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'release'
         run: |
           Rscript -e "tic::before_deploy()"
 
       - name: "[Stage] Deploy"
-        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'release'
         run: Rscript -e "tic::deploy()"
 
       - name: "[Stage] After Deploy"
-        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'release'
         run: Rscript -e "tic::after_deploy()"
 

--- a/R/use-yaml.R
+++ b/R/use-yaml.R
@@ -5,8 +5,6 @@
 #' @param type `[character]`\cr
 #'   Which template to use. The string should be given following the logic
 #'   `<platform>-<action>`. See details for more.
-#' @param deploy `logical(1)`\cr
-#'   Whether to use YAML templates for deployment.
 #'
 #' @section pkgdown:
 #'  If `type` contains "deploy", {tic} by default also sets the environment

--- a/R/use-yaml.R
+++ b/R/use-yaml.R
@@ -1,5 +1,6 @@
 #' @title Use CI YAML templates
-#' @description Installs YAML templates for various CI providers.
+#' @description Installs YAML templates for various CI providers. These function
+#'   are also used within [use_tic()].
 #'
 #' @param type `[character]`\cr
 #'   Which template to use. The string should be given following the logic
@@ -8,19 +9,19 @@
 #'   Whether to use YAML templates for deployment.
 #'
 #' @section pkgdown:
-#'  If a setting including "deploy" is selected, {tic} by default also adds
-#'  the environment var `BUILD_PKGDOWN=true`. This setting triggers a call
-#'  to `pkgdown::build_site()` via the `do_pkgdown` macro in `tic.R`.
+#'  If `type` contains "deploy", {tic} by default also sets the environment
+#'  variable `BUILD_PKGDOWN=true`. This triggers a call to
+#'  `pkgdown::build_site()` via the `do_pkgdown` macro in `tic.R` for the
+#'  respective runners.
 #'
 #'  If a setting  includes "matrix" and builds on multiple R versions, the job
 #'  building on R release is chosen to build the pkgdown site.
 #'
-#' @section Type:
+#' @section YAML Type:
 #' `tic` supports a variety of different YAML templates which follow the
 #'  `<platform>-<action>` pattern. The first one is mandatory, the
 #'  others are optional.
 #'
-#'  * Possible values for `<provider>` are `travis`, and `circle`
 #'  * Possible values for `<platform>` are `linux`, and `macos`, `windows`.
 #'  * Possible values for `<action>` are `matrix` and `deploy`.
 #'
@@ -28,38 +29,49 @@
 #'  For example, for `use_appveyor_yaml()` only `windows` and `windows-matrix`
 #'  are valid.
 #'
-#'  **GitHub Actions** is special in the sense that it support all operating
-#'  systems. Therefore, only the deploy/non/deploy switch is available and it
-#'  does not follow the scheme described above.
+#'  For backward compatibility `use_ghactions_yml()` will be default build and
+#'  deploy on all platforms.
 #'
 #'  Here is a list of all available combinations:
 #'
-#'  | Provider   | Operating system | Deployment | multiple R versions | Call                                                    |
-#'  | -------    | ---------------- | ---------- | ------------------- | ------------------------------------------------------- |
-#'  |----------  |------------------|------------|---------------------|---------------------------------------------------------|
-#'  | Travis     | Linux            | no         | no                  | `use_travis_yml("linux")`                               |
-#'  |            | Linux            | yes        | no                  | `use_travis_yml("linux-deploy")`                        |
-#'  |            | Linux            | no         | yes                 | `use_travis_yml("linux-matrix")`                        |
-#'  |            | Linux            | yes        | yes                 | `use_travis_yml("linux-deploy-matrix")`                 |
-#'  |            | macOS            | no         | no                  | `use_travis_yml("macos")`                               |
-#'  |            | macOS            | yes        | no                  | `use_travis_yml("macos-deploy")`                        |
-#'  |            | macOS            | no         | yes                 | `use_travis_yml("macos-matrix")`                        |
-#'  |            | macOS            | yes        | yes                 | `use_travis_yml("macos-deploy-matrix")`                 |
-#'  |            | Linux + macOS    | no         | no                  | `use_travis_yml("linux-macos")`                         |
-#'  |            | Linux + macOS    | yes        | no                  | `use_travis_yml("linux-macos-deploy")`                  |
-#'  |            | Linux + macOS    | no         | yes                 | `use_travis_yml("linux-macos-matrix")`                  |
-#'  |            | Linux + macOS    | yes        | yes                 | `use_travis_yml("linux-macos-deploy-matrix")`           |
-#'  |----------  |------------------|------------|---------------------|---------------------------------------------------------|
-#'  | Circle     | Linux            | no         | no                  | `use_circle_yml("linux")`                               |
-#'  |            | Linux            | yes        | no                  | `use_travis_yml("linux-deploy")`                        |
-#'  |            | Linux            | no         | yes                 | `use_travis_yml("linux-matrix")`                        |
-#'  |            | Linux            | no         | yes                 | `use_travis_yml("linux-deploy-matrix")`                 |
-#'  |----------  |------------------|------------|---------------------|---------------------------------------------------------|
-#'  | Appveyor   | Windows          | no         | no                  | `use_appveyor_yml("windows")`                           |
-#'  |            | Windows          | no         | yes                 | `use_travis_yml("windows-matrix")`                      |
-#'  |----------  |------------------|------------|---------------------|---------------------------------------------------------|
-#'  | GH Actions | All              | no         | yes                 | `use_ghactions_yml()`                              |
-#'  |            | All              | no         | yes                 | `use_ghactions_yml(deploy = TRUE)`                       |
+#'  | Provider   | Operating system         | Deployment | multiple R versions | Call                                                    |
+#'  | -------    | ----------------         | ---------- | ------------------- | ------------------------------------------------------- |
+#'  |----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+#'  | Travis     | Linux                    | no         | no                  | `use_travis_yml("linux")`                               |
+#'  |            | Linux                    | yes        | no                  | `use_travis_yml("linux-deploy")`                        |
+#'  |            | Linux                    | no         | yes                 | `use_travis_yml("linux-matrix")`                        |
+#'  |            | Linux                    | yes        | yes                 | `use_travis_yml("linux-deploy-matrix")`                 |
+#'  |            | macOS                    | no         | no                  | `use_travis_yml("macos")`                               |
+#'  |            | macOS                    | yes        | no                  | `use_travis_yml("macos-deploy")`                        |
+#'  |            | macOS                    | no         | yes                 | `use_travis_yml("macos-matrix")`                        |
+#'  |            | macOS                    | yes        | yes                 | `use_travis_yml("macos-deploy-matrix")`                 |
+#'  |            | Linux + macOS            | no         | no                  | `use_travis_yml("linux-macos")`                         |
+#'  |            | Linux + macOS            | yes        | no                  | `use_travis_yml("linux-macos-deploy")`                  |
+#'  |            | Linux + macOS            | no         | yes                 | `use_travis_yml("linux-macos-matrix")`                  |
+#'  |            | Linux + macOS            | yes        | yes                 | `use_travis_yml("linux-macos-deploy-matrix")`           |
+#'  |----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+#'  | Circle     | Linux                    | no         | no                  | `use_circle_yml("linux")`                               |
+#'  |            | Linux                    | yes        | no                  | `use_travis_yml("linux-deploy")`                        |
+#'  |            | Linux                    | no         | yes                 | `use_travis_yml("linux-matrix")`                        |
+#'  |            | Linux                    | no         | yes                 | `use_travis_yml("linux-deploy-matrix")`                 |
+#'  |----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+#'  | Appveyor   | Windows                  | no         | no                  | `use_appveyor_yml("windows")`                           |
+#'  |            | Windows                  | no         | yes                 | `use_travis_yml("windows-matrix")`                      |
+#'  |----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+#'  | GH Actions | Linux                    | no         | no                  | `use_ghactions_yml("linux")`                           -|
+#'  |            | Linux                    | yes        | no                  | `use_ghactions_yml("linux-deploy)`                      |
+#'  |            | macOS                    | no         | no                  | `use_ghactions_yml("macos)`                             |
+#'  |            | macOS                    | yes        | no                  | `use_ghactions_yml("macos-deploy)`                      |
+#'  |            | Windows                  | no         | no                  | `use_ghactions_yml("windows)`                           |
+#'  |            | Windows                  | yes        | no                  | `use_ghactions_yml("windows-deploy)`                    |
+#'  |            | Linux + macOS            | no         | no                  | `use_ghactions_yml("linux-macos")`                      |
+#'  |            | Linux + macOS            | yes        | no                  | `use_ghactions_yml("linux-macos-deploy")`               |
+#'  |            | Linux + Windows          | no         | no                  | `use_ghactions_yml("linux-windows")`                    |
+#'  |            | Linux + Windows          | yes        | no                  | `use_ghactions_yml("linux-windows-deploy")`             |
+#'  |            | macOS + Windows          | no         | no                  | `use_ghactions_yml("macos-windows")`                    |
+#'  |            | macOS + Windows          | yes        | no                  | `use_ghactions_yml("macos-windows-deploy")`             |
+#'  |            | Linux + macOS + Windows  | no         | no                  | `use_ghactions_yml("linux-macos-windows")`              |
+#'  |            | Linux + macOS + Windows  | yes        | no                  | `use_ghactions_yml("linux-macos-windows-deploy")`       |
 #' @name yaml_templates
 #' @aliases yaml_templates
 #' @export
@@ -270,27 +282,86 @@ use_circle_yml <- function(type) {
 
 #' @rdname yaml_templates
 #' @export
-use_ghactions_yml <- function(type = "all", deploy = FALSE) {
-
-  if (deploy == TRUE) {
-    type = "all-deploy"
-  }
+use_ghactions_yml <- function(type = "all") {
 
   # .ccache dir lives in the package root because we cannot write elsewhere
   # -> need to ignore it for R CMD check
   usethis::use_build_ignore(c(".ccache", ".github"))
   usethis::use_build_ignore("^clang-.*", escape = FALSE)
+  usethis::use_build_ignore("^gfortran.*", escape = FALSE)
 
-  if (type == "linux" || type == "macOS" || type == "linux-macos" |
-    type == "linux-macos-windows" || type == "all") {
+  if (type == "linux-matrix" || type == "linux") {
+    meta <- readLines(system.file("templates/ghactions-meta-linux.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    template <- c(meta, env, core)
+  } else if (type == "linux-matrix-deploy" || type == "linux-deploy-matrix" || type == "linux-deploy") {
+    meta <- readLines(system.file("templates/ghactions-meta-linux-deploy.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    deploy <- readLines(system.file("templates/ghactions-deploy.yml", package = "tic"))
+    template <- c(meta, env, core, deploy)
+  } else if (type == "macos-matrix" || type == "macos") {
+    meta <- readLines(system.file("templates/ghactions-meta-macos.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    template <- c(meta, env, core)
+  } else if (type == "macos-matrix-deploy" || type == "macos-deploy-matrix" || type == "macos-deploy") {
+    meta <- readLines(system.file("templates/ghactions-meta-macos-deploy.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    deploy <- readLines(system.file("templates/ghactions-deploy.yml", package = "tic"))
+    template <- c(meta, env, core, deploy)
+  } else if (type == "windows-matrix" || type == "windows") {
+    meta <- readLines(system.file("templates/ghactions-meta-windows.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    template <- c(meta, env, core)
+  } else if (type == "windows-matrix-deploy" || type == "windows-deploy-matrix" || type == "windows-deploy") {
+    meta <- readLines(system.file("templates/ghactions-meta-windows-deploy.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    deploy <- readLines(system.file("templates/ghactions-deploy.yml", package = "tic"))
+    template <- c(meta, env, core, deploy)
+  } else if (type == "linux-macos" || type == "linux-macos-matrix") {
+    meta <- readLines(system.file("templates/ghactions-meta-linux-macos.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    template <- c(meta, env, core)
+  } else if (type == "linux-macos-deploy" || type == "linux-macos-deploy-matrix") {
+    meta <- readLines(system.file("templates/ghactions-meta-linux-macos.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    deploy <- readLines(system.file("templates/ghactions-deploy.yml", package = "tic"))
+    template <- c(meta, env, core, deploy)
+  } else if (type == "linux-windows" || type == "linux-windows-matrix") {
+    meta <- readLines(system.file("templates/ghactions-meta-linux-windows.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    template <- c(meta, env, core)
+  } else if (type == "linux-windows-deploy" || type == "linux-windows-deploy-matrix") {
+    meta <- readLines(system.file("templates/ghactions-meta-linux-windows.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    deploy <- readLines(system.file("templates/ghactions-deploy.yml", package = "tic"))
+    template <- c(meta, env, core, deploy)
+  } else if (type == "macos-windows" || type == "macos-windows-matrix") {
+    meta <- readLines(system.file("templates/ghactions-meta-macos-windows.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    template <- c(meta, env, core)
+  } else if (type == "macos-windows-deploy" || type == "macos-windows-deploy-matrix") {
+    meta <- readLines(system.file("templates/ghactions-meta-macos-windows.yml", package = "tic"))
+    env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
+    core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
+    deploy <- readLines(system.file("templates/ghactions-deploy.yml", package = "tic"))
+    template <- c(meta, env, core, deploy)
+  } else if (type == "linux-macos-windows") {
     meta <- readLines(system.file("templates/ghactions-meta.yml", package = "tic"))
     env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
     core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))
     template <- c(meta, env, core)
-  } else if (type == "linux-deploy" || type == "macOS-deploy" |
-    type == "linux-macos-deploy" ||
-    type == "linux-macos-windows-deploy" ||
-    type == "all-deploy") {
+  } else if (type == "linux-macos-windows-deploy" || type == "all") {
     meta <- readLines(system.file("templates/ghactions-meta.yml", package = "tic"))
     env <- readLines(system.file("templates/ghactions-env.yml", package = "tic"))
     core <- readLines(system.file("templates/ghactions-core.yml", package = "tic"))

--- a/R/use_tic.R
+++ b/R/use_tic.R
@@ -291,7 +291,86 @@ use_tic <- function(wizard = interactive(),
 
   cli_h2("GitHub Actions")
 
-  if (ghactions_in(windows) || ghactions_in(linux) || ghactions_in(mac)) {
+  if (ghactions_in(linux) && ghactions_in(mac)) {
+
+    if (ghactions_in(matrix)) {
+      if (ghactions_in(deploy)) {
+        use_ghactions_yml("linux-macos-deploy-matrix")
+      } else {
+        use_ghactions_yml("linux-macos-matrix")
+      }
+    } else {
+      if (ghactions_in(deploy)) {
+        use_ghactions_yml("linux-macos-deploy")
+      } else {
+        use_ghactions_yml("linux-macos")
+      }
+    }
+  } else if (ghactions_in(linux) && ghactions_in(windows)) {
+
+    if (ghactions_in(matrix)) {
+      if (ghactions_in(deploy)) {
+        use_ghactions_yml("linux-windows-deploy-matrix")
+      } else {
+        use_ghactions_yml("linux-windows-matrix")
+      }
+    } else {
+      if (ghactions_in(deploy)) {
+        use_ghactions_yml("linux-windows-deploy")
+      } else {
+        use_ghactions_yml("linux-windows")
+      }
+    }
+  } else if (ghactions_in(mac) && ghactions_in(windows)) {
+
+    if (ghactions_in(matrix)) {
+      if (ghactions_in(deploy)) {
+        use_ghactions_yml("macos-windows-deploy-matrix")
+      } else {
+        use_ghactions_yml("macos-windows-matrix")
+      }
+    } else {
+      if (ghactions_in(deploy)) {
+        use_ghactions_yml("macos-windows-deploy")
+      } else {
+        use_ghactions_yml("macos-windows")
+      }
+    }
+  } else if (ghactions_in(mac)) {
+
+    if (ghactions_in(deploy)) {
+      # build matrix
+      if (ghactions_in(matrix)) {
+        use_ghactions_yml("macos-deploy-matrix")
+      } else {
+        use_ghactions_yml("macos-deploy")
+      }
+    } else {
+      # build matrix
+      if (ghactions_in(matrix)) {
+        use_ghactions_yml("macos-matrix")
+      } else {
+        use_ghactions_yml("macos")
+      }
+    }
+  } else if (ghactions_in(linux)) {
+    # deployment
+    if (ghactions_in(deploy)) {
+      # build matrix
+      if (ghactions_in(matrix)) {
+        use_ghactions_yml("linux-deploy-matrix")
+      } else {
+        use_ghactions_yml("linux-deploy")
+      }
+    } else {
+      # build matrix
+      if (ghactions_in(matrix)) {
+        use_ghactions_yml("linux-matrix")
+      } else {
+        use_ghactions_yml("linux")
+      }
+    }
+  } else if (ghactions_in(windows) && ghactions_in(linux) && ghactions_in(mac)) {
     if (ghactions_in(deploy)) {
       use_ghactions_yml("all-deploy")
     } else {
@@ -408,6 +487,7 @@ ci_menu <- function(choices, title) {
 #' use_tic_r("blogdown", deploy_on = "all")
 #' }
 use_tic_r <- function(repo_type, deploy_on = "none") {
+
   cli_par()
   cli_end()
   cli_h2("tic.R")

--- a/inst/templates/ghactions-core.yml
+++ b/inst/templates/ghactions-core.yml
@@ -51,7 +51,7 @@
         if: runner.os == 'Linux'
         run: |
           sudo apt install ccache libcurl4-openssl-dev
-          mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache gcc -std=gnu99\nCXX=ccache g++\nCXX11=ccache g++ -std=gnu99\nCXX14=ccache g++ -std=gnu99\nC11=ccache g++\nC14=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
+          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
 
       # install ccache and write config file
       # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
@@ -61,7 +61,7 @@
           brew install ccache
           wget https://cran.r-project.org/bin/macosx/tools/clang-7.0.0.pkg
           sudo installer -package clang-7.0.0.pkg -target /
-          mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache /usr/local/clang7/bin/clang\nCC11=ccache /usr/local/clang7/bin/clang\nCC14=ccache /usr/local/clang7/bin/clang\nCXX=ccache /usr/local/clang7/bin/clang++\nCXX11=ccache /usr/local/clang7/bin/clang++\nCXX14=ccache /usr/local/clang7/bin/clang++\nC11=ccache /usr/local/clang7/bin/clang++\nC14=ccache /usr/local/clang7/bin/clang++\nF77=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
+          mkdir -p ~/.R && echo -e 'CC=ccache /usr/local/clang7/bin/clang\nCXX=ccache /usr/local/clang7/bin/clang++\nF77=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
 
       # install ccache and write config file
       # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
@@ -69,9 +69,19 @@
         if: runner.os == 'macOS' && matrix.config.r == 'devel'
         run: |
           brew install ccache
-          wget https://cran.r-project.org/bin/macosx/tools/clang-8.0.0.pkg
-          sudo installer -package clang-8.0.0.pkg -target /
-          mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache /usr/local/clang8/bin/clang\nCC11=ccache /usr/local/clang8/bin/clang\nCC14=ccache /usr/local/clang8/bin/clang\nCXX=ccache /usr/local/clang8/bin/clang++\nCXX11=ccache /usr/local/clang8/bin/clang++\nCXX14=ccache /usr/local/clang8/bin/clang++\nC11=ccache /usr/local/clang8/bin/clang++\nC14=ccache /usr/local/clang8/bin/clang++\nF88=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
+          # install SDK 10.13 (High Sierra, used by CRAN)
+          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
+          tar fxz MacOSX10.13.sdk.tar.xz
+          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
+          rm -rf MacOSX10.13*
+          # install gfortran 8.2 (used by CRAN)
+          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
+          sudo hdiutil attach gfortran*.dmg
+          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
+          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
+          rm gfortran-8*
+          # set compiler flags
+          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # for some strange Windows reason this step and the next one need to be decoupled
       - name: "[Stage] Prepare"
@@ -87,7 +97,7 @@
       - name: "[Stage] Prepare & Install (macOS-devel)"
         if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
         run: |
-          echo -e 'options(pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
+          echo -e 'options(Ncpus = 4, pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
           Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
 
       - name: "[Stage] Script"

--- a/inst/templates/ghactions-env.yml
+++ b/inst/templates/ghactions-env.yml
@@ -15,3 +15,5 @@
       # if you use bookdown or blogdown, replace "PKGDOWN" by the respective
       # capitalized term. This also might need to be done in tic.R
       BUILD_PKGDOWN: ${{ matrix.config.pkgdown }} 
+      # macOS >= 10.15.4 linking
+      SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk

--- a/inst/templates/ghactions-meta-linux-deploy.yml
+++ b/inst/templates/ghactions-meta-linux-deploy.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: ubuntu-latest, r: "release", pkgdown: "true" }
+

--- a/inst/templates/ghactions-meta-linux-macos.yml
+++ b/inst/templates/ghactions-meta-linux-macos.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: ubuntu-latest, r: "release" }
+          - { os: macos-latest, r: "release", pkgdown: "true" }
+          - { os: macos-latest, r: "devel" }
+

--- a/inst/templates/ghactions-meta-linux-windows.yml
+++ b/inst/templates/ghactions-meta-linux-windows.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: ubuntu-latest, r: "release", pkgdown: "true" }
+          - { os: windows-latest, r: "release" }
+

--- a/inst/templates/ghactions-meta-linux.yml
+++ b/inst/templates/ghactions-meta-linux.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: ubuntu-latest, r: "release" }
+

--- a/inst/templates/ghactions-meta-macos-deploy.yml
+++ b/inst/templates/ghactions-meta-macos-deploy.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: macos-latest, r: "release", pkgdown: "true" }
+          - { os: macos-latest, r: "devel" }
+

--- a/inst/templates/ghactions-meta-macos-windows.yml
+++ b/inst/templates/ghactions-meta-macos-windows.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: macos-latest, r: "release" }
+          - { os: macos-latest, r: "devel", pkgdown: "true"}
+          - { os: windows-latest, r: "release" }
+

--- a/inst/templates/ghactions-meta-macos.yml
+++ b/inst/templates/ghactions-meta-macos.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: macos-latest, r: "release" }
+          - { os: macos-latest, r: "devel" }
+

--- a/inst/templates/ghactions-meta-windows-deploy.yml
+++ b/inst/templates/ghactions-meta-windows-deploy.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: windows-latest, r: "release", pkgdown: "true" }

--- a/inst/templates/ghactions-meta-windows.yml
+++ b/inst/templates/ghactions-meta-windows.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # comment out lines if you do not want to build on certain platforms
+          - { os: windows-latest, r: "release" }
+
+

--- a/man/yaml_templates.Rd
+++ b/man/yaml_templates.Rd
@@ -20,9 +20,6 @@ use_ghactions_yml(type = "all")
 \item{type}{\verb{[character]}\cr
 Which template to use. The string should be given following the logic
 \verb{<platform>-<action>}. See details for more.}
-
-\item{deploy}{\code{logical(1)}\cr
-Whether to use YAML templates for deployment.}
 }
 \description{
 Installs YAML templates for various CI providers. These function

--- a/man/yaml_templates.Rd
+++ b/man/yaml_templates.Rd
@@ -14,7 +14,7 @@ use_appveyor_yml(type)
 
 use_circle_yml(type)
 
-use_ghactions_yml(type = "all", deploy = FALSE)
+use_ghactions_yml(type = "all")
 }
 \arguments{
 \item{type}{\verb{[character]}\cr
@@ -25,25 +25,26 @@ Which template to use. The string should be given following the logic
 Whether to use YAML templates for deployment.}
 }
 \description{
-Installs YAML templates for various CI providers.
+Installs YAML templates for various CI providers. These function
+are also used within \code{\link[=use_tic]{use_tic()}}.
 }
 \section{pkgdown}{
 
-If a setting including "deploy" is selected, {tic} by default also adds
-the environment var \code{BUILD_PKGDOWN=true}. This setting triggers a call
-to \code{pkgdown::build_site()} via the \code{do_pkgdown} macro in \code{tic.R}.
+If \code{type} contains "deploy", {tic} by default also sets the environment
+variable \code{BUILD_PKGDOWN=true}. This triggers a call to
+\code{pkgdown::build_site()} via the \code{do_pkgdown} macro in \code{tic.R} for the
+respective runners.
 
 If a setting  includes "matrix" and builds on multiple R versions, the job
 building on R release is chosen to build the pkgdown site.
 }
 
-\section{Type}{
+\section{YAML Type}{
 
 \code{tic} supports a variety of different YAML templates which follow the
 \verb{<platform>-<action>} pattern. The first one is mandatory, the
 others are optional.
 \itemize{
-\item Possible values for \verb{<provider>} are \code{travis}, and \code{circle}
 \item Possible values for \verb{<platform>} are \code{linux}, and \code{macos}, \code{windows}.
 \item Possible values for \verb{<action>} are \code{matrix} and \code{deploy}.
 }
@@ -52,9 +53,8 @@ Not every combinations is supported on all CI systems.
 For example, for \code{use_appveyor_yaml()} only \code{windows} and \code{windows-matrix}
 are valid.
 
-\strong{GitHub Actions} is special in the sense that it support all operating
-systems. Therefore, only the deploy/non/deploy switch is available and it
-does not follow the scheme described above.
+For backward compatibility \code{use_ghactions_yml()} will be default build and
+deploy on all platforms.
 
 Here is a list of all available combinations:\tabular{lllll}{
    Provider \tab Operating system \tab Deployment \tab multiple R versions \tab Call \cr
@@ -80,8 +80,20 @@ Here is a list of all available combinations:\tabular{lllll}{
    Appveyor \tab Windows \tab no \tab no \tab \code{use_appveyor_yml("windows")} \cr
     \tab Windows \tab no \tab yes \tab \code{use_travis_yml("windows-matrix")} \cr
    ---------- \tab ------------------ \tab ------------ \tab --------------------- \tab --------------------------------------------------------- \cr
-   GH Actions \tab All \tab no \tab yes \tab \code{use_ghactions_yml()} \cr
-    \tab All \tab no \tab yes \tab \code{use_ghactions_yml(deploy = TRUE)} \cr
+   GH Actions \tab Linux \tab no \tab no \tab \code{use_ghactions_yml("linux")}                           - \cr
+    \tab Linux \tab yes \tab no \tab \verb{use_ghactions_yml("linux-deploy)} \cr
+    \tab macOS \tab no \tab no \tab \verb{use_ghactions_yml("macos)} \cr
+    \tab macOS \tab yes \tab no \tab \verb{use_ghactions_yml("macos-deploy)} \cr
+    \tab Windows \tab no \tab no \tab \verb{use_ghactions_yml("windows)} \cr
+    \tab Windows \tab yes \tab no \tab \verb{use_ghactions_yml("windows-deploy)} \cr
+    \tab Linux + macOS \tab no \tab no \tab \code{use_ghactions_yml("linux-macos")} \cr
+    \tab Linux + macOS \tab yes \tab no \tab \code{use_ghactions_yml("linux-macos-deploy")} \cr
+    \tab Linux + Windows \tab no \tab no \tab \code{use_ghactions_yml("linux-windows")} \cr
+    \tab Linux + Windows \tab yes \tab no \tab \code{use_ghactions_yml("linux-windows-deploy")} \cr
+    \tab macOS + Windows \tab no \tab no \tab \code{use_ghactions_yml("macos-windows")} \cr
+    \tab macOS + Windows \tab yes \tab no \tab \code{use_ghactions_yml("macos-windows-deploy")} \cr
+    \tab Linux + macOS + Windows \tab no \tab no \tab \code{use_ghactions_yml("linux-macos-windows")} \cr
+    \tab Linux + macOS + Windows \tab yes \tab no \tab \code{use_ghactions_yml("linux-macos-windows-deploy")} \cr
 }
 }
 

--- a/tic.R
+++ b/tic.R
@@ -1,3 +1,5 @@
+do_package_checks()
+
 if (ci_on_ghactions() && ci_is_env("BUILD_PKGDOWN", "true")) {
   get_stage("before_deploy") %>%
     add_step(step_install_github("ropensci/rotemplate"))

--- a/tic.R
+++ b/tic.R
@@ -1,3 +1,5 @@
 if (ci_on_ghactions() && ci_is_env("BUILD_PKGDOWN", "true")) {
+  get_stage("before_deploy") %>%
+    add_step(step_install_github("ropensci/rotemplate"))
   do_pkgdown()
 }


### PR DESCRIPTION
fixes #244 

This PR overcomes my laziness and adjusts the usage of `use_ghactions_yml()` to how all other `use_*_yaml()` functions work.

See `?yaml_templates` for all new options.

In addition packages on R-devel macOS are now installed in parallel again.

## R 4.0 macOS toolchain adjustments

CRAN will use gfortran v8.2 and Apples native clang compiler for R 4.0 on macOS.
In addition, the build platform will be High Sierra (10.13). To mimic this scenario in the closest way possible, the 10.13 SDK is used.
This does **not** complicate things but rather simplifies it because the 10.15 SDK has a lot of issues with source installations.

In addition, since 10.15.4 one needs to set `SDKROOT` globally to the SDK path so that certain system libs are found ([related](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes#3035623)).