### PR TITLE
Add argument `force` to `step_do_push_deploy()` for adding the `--force` flag to git calls

### DIFF
--- a/R/macro-blogdown.R
+++ b/R/macro-blogdown.R
@@ -42,6 +42,7 @@ do_blogdown <- function(...,
                         remote_url = NULL,
                         commit_message = NULL,
                         commit_paths = ".",
+                        force = FALSE,
                         private_key_name = "TIC_DEPLOY_KEY",
                         cname = NULL) {
 
@@ -113,7 +114,8 @@ do_blogdown <- function(...,
       add_step(step_do_push_deploy(
         path = !!enquo(path),
         commit_message = !!enquo(commit_message),
-        commit_paths = !!enquo(commit_paths)
+        commit_paths = !!enquo(commit_paths),
+        force = !!enquo(force)
       ))
   }
 

--- a/R/macro-bookdown.R
+++ b/R/macro-bookdown.R
@@ -42,6 +42,7 @@ do_bookdown <- function(...,
                         remote_url = NULL,
                         commit_message = NULL,
                         commit_paths = ".",
+                        force = FALSE,
                         private_key_name = "TIC_DEPLOY_KEY",
                         cname = NULL) {
 
@@ -110,7 +111,8 @@ do_bookdown <- function(...,
       add_step(step_do_push_deploy(
         path = !!enquo(path),
         commit_message = !!enquo(commit_message),
-        commit_paths = !!enquo(commit_paths)
+        commit_paths = !!enquo(commit_paths),
+        force = !!enquo(force)
       ))
   }
 

--- a/R/macro-drat.R
+++ b/R/macro-drat.R
@@ -49,6 +49,7 @@ do_drat <- function(repo_slug = NULL,
                     remote_url = NULL,
                     commit_message = NULL,
                     commit_paths = ".",
+                    force = FALSE,
                     private_key_name = "TIC_DEPLOY_KEY",
                     deploy_dev = FALSE) {
 
@@ -80,7 +81,8 @@ do_drat <- function(repo_slug = NULL,
     add_step(step_do_push_deploy(
       path = !!enquo(path),
       commit_message = !!enquo(commit_message),
-      commit_paths = !!enquo(commit_paths)
+      commit_paths = !!enquo(commit_paths),
+      force = !!enquo(force)
     ))
 
   dsl_get()

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -43,6 +43,7 @@ do_pkgdown <- function(...,
                        remote_url = NULL,
                        commit_message = NULL,
                        commit_paths = ".",
+                       force = FALSE,
                        private_key_name = "TIC_DEPLOY_KEY") {
 
   #' @param deploy `[flag]`\cr
@@ -103,7 +104,8 @@ do_pkgdown <- function(...,
       add_step(step_do_push_deploy(
         path = !!enquo(path),
         commit_message = !!enquo(commit_message),
-        commit_paths = !!enquo(commit_paths)
+        commit_paths = !!enquo(commit_paths),
+        force = !!enquo(force)
       ))
   }
 

--- a/R/macro-readme-rmd.R
+++ b/R/macro-readme-rmd.R
@@ -35,6 +35,7 @@ NULL
 do_readme_rmd <- function(checkout = TRUE,
                           remote_url = NULL,
                           commit_message = NULL,
+                          force = FALSE,
                           private_key_name = "TIC_DEPLOY_KEY") {
 
   #' @description
@@ -62,7 +63,8 @@ do_readme_rmd <- function(checkout = TRUE,
     add_step(step_do_push_deploy(
       path = ".",
       commit_message = !!enquo(commit_message),
-      commit_paths = "README.md"
+      commit_paths = "README.md",
+      force = !!enquo(force)
     ))
 
   dsl_get()

--- a/R/steps-git.R
+++ b/R/steps-git.R
@@ -40,9 +40,11 @@ Git <- R6Class(
 )
 
 # SetupPushDeploy --------------------------------------------------------------
+
 SetupPushDeploy <- R6Class( # nolint
   "SetupPushDeploy",
   inherit = TicStep,
+
 
   public = list(
     initialize = function(path = ".",
@@ -216,6 +218,7 @@ step_setup_push_deploy <- function(path = ".",
                                    orphan = FALSE,
                                    remote_url = NULL,
                                    checkout = TRUE) {
+
   SetupPushDeploy$new(
     path = path,
     branch = branch,
@@ -276,7 +279,8 @@ DoPushDeploy <- R6Class(
 
     commit = function() {
       message("Staging: ", paste(private$commit_paths, collapse = ", "))
-      git2r::add(private$git$get_repo(), private$commit_paths,
+      git2r::add(private$git$get_repo(),
+        private$commit_paths,
         force = private$force
       )
 

--- a/R/steps-git.R
+++ b/R/steps-git.R
@@ -1,3 +1,5 @@
+# Git --------------------------------------------------------------------------
+
 Git <- R6Class(
   "Git",
   public = list(
@@ -37,6 +39,7 @@ Git <- R6Class(
   )
 )
 
+# SetupPushDeploy --------------------------------------------------------------
 SetupPushDeploy <- R6Class( # nolint
   "SetupPushDeploy",
   inherit = TicStep,
@@ -74,7 +77,6 @@ SetupPushDeploy <- R6Class( # nolint
       private$orphan <- orphan
       private$remote_url <- remote_url
       private$checkout <- checkout
-      private$force <- force
     },
 
     prepare = function() {
@@ -132,7 +134,7 @@ SetupPushDeploy <- R6Class( # nolint
       if (!private$orphan) {
         message("Fetching from remote ", remote_name)
         tryCatch(
-          { # nolint
+          {
             remote_branch <- private$try_fetch()
             if (!is.null(remote_branch)) {
               message("Remote branch is ", remote_branch$name)
@@ -222,6 +224,8 @@ step_setup_push_deploy <- function(path = ".",
     checkout = checkout,
   )
 }
+
+# DoPushDeploy -----------------------------------------------------------------
 
 DoPushDeploy <- R6Class(
   "DoPushDeploy",
@@ -407,11 +411,14 @@ step_do_push_deploy <- function(path = ".",
                                 commit_paths = ".",
                                 force = FALSE) {
   DoPushDeploy$new(
-    path = path, commit_message = commit_message, commit_paths = commit_paths,
+    path = path,
+    commit_message = commit_message,
+    commit_paths = commit_paths,
     force = FALSE
   )
 }
 
+# PushDeploy -------------------------------------------------------------------
 PushDeploy <- R6Class(
   "PushDeploy",
   inherit = TicStep,

--- a/R/steps-git.R
+++ b/R/steps-git.R
@@ -224,7 +224,7 @@ step_setup_push_deploy <- function(path = ".",
     branch = branch,
     orphan = orphan,
     remote_url = remote_url,
-    checkout = checkout,
+    checkout = checkout
   )
 }
 

--- a/R/steps-git.R
+++ b/R/steps-git.R
@@ -414,11 +414,12 @@ step_do_push_deploy <- function(path = ".",
     path = path,
     commit_message = commit_message,
     commit_paths = commit_paths,
-    force = FALSE
+    force = force
   )
 }
 
 # PushDeploy -------------------------------------------------------------------
+
 PushDeploy <- R6Class(
   "PushDeploy",
   inherit = TicStep,
@@ -435,13 +436,17 @@ PushDeploy <- R6Class(
       orphan <- (path != ".")
 
       private$setup <- step_setup_push_deploy(
-        path = path, branch = branch, orphan = orphan, remote_url = remote_url,
+        path = path,
+        branch = branch,
+        orphan = orphan,
+        remote_url = remote_url,
         checkout = FALSE
       )
 
       private$do <- step_do_push_deploy(
         path = path,
-        commit_message = commit_message, commit_paths = commit_paths,
+        commit_message = commit_message,
+        commit_paths = commit_paths,
         force = force
       )
     },
@@ -467,6 +472,8 @@ PushDeploy <- R6Class(
   )
 )
 
+# step_push_deploy -------------------------------------------------------------
+
 #' Step: Setup and perform push deploy
 #'
 #' @description
@@ -488,7 +495,7 @@ PushDeploy <- R6Class(
 #'
 #' For more control, create two separate steps with
 #' `step_setup_push_deploy()` and `step_do_push_deploy()`,
-#' and create the files to be deployed inbetween these steps.
+#' and create the files to be deployed in between these steps.
 #'
 #' @inheritParams step_setup_push_deploy
 #' @inheritParams step_do_push_deploy

--- a/R/steps-git.R
+++ b/R/steps-git.R
@@ -258,7 +258,7 @@ DoPushDeploy <- R6Class(
 
     commit = function() {
       message("Staging: ", paste(private$commit_paths, collapse = ", "))
-      git2r::add(private$git$get_repo(), private$commit_paths, force = TRUE)
+      git2r::add(private$git$get_repo(), private$commit_paths)
 
       message("Checking changed files")
       status <- git2r::status(

--- a/man/do_blogdown.Rd
+++ b/man/do_blogdown.Rd
@@ -15,6 +15,7 @@ do_blogdown(
   remote_url = NULL,
   commit_message = NULL,
   commit_paths = ".",
+  force = FALSE,
   private_key_name = "TIC_DEPLOY_KEY",
   cname = NULL
 )
@@ -67,6 +68,9 @@ and avoiding recursive CI runs.}
 \item{commit_paths}{\verb{[character]}\cr
 Restrict the set of directories and/or files added to Git before deploying.
 Default: deploy all files.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 
 \item{private_key_name}{\code{string}\cr
 Only needed when deploying from builds on Travis CI or GitHub Actions.

--- a/man/do_bookdown.Rd
+++ b/man/do_bookdown.Rd
@@ -15,6 +15,7 @@ do_bookdown(
   remote_url = NULL,
   commit_message = NULL,
   commit_paths = ".",
+  force = FALSE,
   private_key_name = "TIC_DEPLOY_KEY",
   cname = NULL
 )
@@ -67,6 +68,9 @@ and avoiding recursive CI runs.}
 \item{commit_paths}{\verb{[character]}\cr
 Restrict the set of directories and/or files added to Git before deploying.
 Default: deploy all files.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 
 \item{private_key_name}{\code{string}\cr
 Only needed when deploying from builds on Travis CI or GitHub Actions.

--- a/man/do_drat.Rd
+++ b/man/do_drat.Rd
@@ -13,6 +13,7 @@ do_drat(
   remote_url = NULL,
   commit_message = NULL,
   commit_paths = ".",
+  force = FALSE,
   private_key_name = "TIC_DEPLOY_KEY",
   deploy_dev = FALSE
 )
@@ -45,6 +46,9 @@ and avoiding recursive CI runs.}
 \item{commit_paths}{\verb{[character]}\cr
 Restrict the set of directories and/or files added to Git before deploying.
 Default: deploy all files.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 
 \item{private_key_name}{\code{string}\cr
 Only needed when deploying from builds on Travis CI or GitHub Actions.

--- a/man/do_pkgdown.Rd
+++ b/man/do_pkgdown.Rd
@@ -15,6 +15,7 @@ do_pkgdown(
   remote_url = NULL,
   commit_message = NULL,
   commit_paths = ".",
+  force = FALSE,
   private_key_name = "TIC_DEPLOY_KEY"
 )
 }
@@ -63,6 +64,9 @@ and avoiding recursive CI runs.}
 \item{commit_paths}{\verb{[character]}\cr
 Restrict the set of directories and/or files added to Git before deploying.
 Default: deploy all files.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 
 \item{private_key_name}{\code{string}\cr
 Only needed when deploying from builds on Travis CI or GitHub Actions.

--- a/man/do_readme_rmd.Rd
+++ b/man/do_readme_rmd.Rd
@@ -8,6 +8,7 @@ do_readme_rmd(
   checkout = TRUE,
   remote_url = NULL,
   commit_message = NULL,
+  force = FALSE,
   private_key_name = "TIC_DEPLOY_KEY"
 )
 }
@@ -24,6 +25,9 @@ current GitHub repository.}
 \item{commit_message}{\verb{[string]}\cr
 Commit message to use, defaults to a useful message linking to the CI build
 and avoiding recursive CI runs.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 
 \item{private_key_name}{\code{string}\cr
 Only needed when deploying from builds on Travis CI or GitHub Actions.

--- a/man/step_do_push_deploy.Rd
+++ b/man/step_do_push_deploy.Rd
@@ -4,7 +4,12 @@
 \alias{step_do_push_deploy}
 \title{Step: Perform push deploy}
 \usage{
-step_do_push_deploy(path = ".", commit_message = NULL, commit_paths = ".")
+step_do_push_deploy(
+  path = ".",
+  commit_message = NULL,
+  commit_paths = ".",
+  force = FALSE
+)
 }
 \arguments{
 \item{path}{\verb{[string]}\cr
@@ -18,6 +23,9 @@ and avoiding recursive CI runs.}
 \item{commit_paths}{\verb{[character]}\cr
 Restrict the set of directories and/or files added to Git before deploying.
 Default: deploy all files.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 }
 \description{
 Commits and pushes to a repo prepared by \code{\link[=step_setup_push_deploy]{step_setup_push_deploy()}}.

--- a/man/step_push_deploy.Rd
+++ b/man/step_push_deploy.Rd
@@ -55,7 +55,7 @@ can be supported (and will be used).
 
 For more control, create two separate steps with
 \code{step_setup_push_deploy()} and \code{step_do_push_deploy()},
-and create the files to be deployed inbetween these steps.
+and create the files to be deployed in between these steps.
 }
 \examples{
 \dontrun{

--- a/man/step_push_deploy.Rd
+++ b/man/step_push_deploy.Rd
@@ -9,7 +9,8 @@ step_push_deploy(
   branch = NULL,
   remote_url = NULL,
   commit_message = NULL,
-  commit_paths = "."
+  commit_paths = ".",
+  force = FALSE
 )
 }
 \arguments{
@@ -31,9 +32,12 @@ and avoiding recursive CI runs.}
 \item{commit_paths}{\verb{[character]}\cr
 Restrict the set of directories and/or files added to Git before deploying.
 Default: deploy all files.}
+
+\item{force}{\verb{[logical]}\cr
+Add \code{--force} flag to git commands?}
 }
 \description{
-Clones a repo, inits author information, sets up remotes,
+Clones a repo, initializes author information, sets up remotes,
 commits, and pushes.
 Combines \code{\link[=step_setup_push_deploy]{step_setup_push_deploy()}} with \code{checkout = FALSE} and
 a suitable \code{orphan} argument,

--- a/man/yaml_templates.Rd
+++ b/man/yaml_templates.Rd
@@ -53,45 +53,44 @@ are valid.
 For backward compatibility \code{use_ghactions_yml()} will be default build and
 deploy on all platforms.
 
-Here is a list of all available combinations:nolint start\tabular{lllll}{
-   Provider \tab Operating system \tab Deployment \tab multiple R versions \tab Call \cr
-   ---------- \tab ------------------ \tab ------------ \tab --------------------- \tab --------------------------------------------------------- \cr
-   Travis \tab Linux \tab no \tab no \tab \code{use_travis_yml("linux")} \cr
-    \tab Linux \tab yes \tab no \tab \code{use_travis_yml("linux-deploy")} \cr
-    \tab Linux \tab no \tab yes \tab \code{use_travis_yml("linux-matrix")} \cr
-    \tab Linux \tab yes \tab yes \tab \code{use_travis_yml("linux-deploy-matrix")} \cr
-    \tab macOS \tab no \tab no \tab \code{use_travis_yml("macos")} \cr
-    \tab macOS \tab yes \tab no \tab \code{use_travis_yml("macos-deploy")} \cr
-    \tab macOS \tab no \tab yes \tab \code{use_travis_yml("macos-matrix")} \cr
-    \tab macOS \tab yes \tab yes \tab \code{use_travis_yml("macos-deploy-matrix")} \cr
-    \tab Linux + macOS \tab no \tab no \tab \code{use_travis_yml("linux-macos")} \cr
-    \tab Linux + macOS \tab yes \tab no \tab \code{use_travis_yml("linux-macos-deploy")} \cr
-    \tab Linux + macOS \tab no \tab yes \tab \code{use_travis_yml("linux-macos-matrix")} \cr
-    \tab Linux + macOS \tab yes \tab yes \tab \code{use_travis_yml("linux-macos-deploy-matrix")} \cr
-   ---------- \tab ------------------ \tab ------------ \tab --------------------- \tab --------------------------------------------------------- \cr
-   Circle \tab Linux \tab no \tab no \tab \code{use_circle_yml("linux")} \cr
-    \tab Linux \tab yes \tab no \tab \code{use_travis_yml("linux-deploy")} \cr
-    \tab Linux \tab no \tab yes \tab \code{use_travis_yml("linux-matrix")} \cr
-    \tab Linux \tab no \tab yes \tab \code{use_travis_yml("linux-deploy-matrix")} \cr
-   ---------- \tab ------------------ \tab ------------ \tab --------------------- \tab --------------------------------------------------------- \cr
-   Appveyor \tab Windows \tab no \tab no \tab \code{use_appveyor_yml("windows")} \cr
-    \tab Windows \tab no \tab yes \tab \code{use_travis_yml("windows-matrix")} \cr
-   ---------- \tab ------------------ \tab ------------ \tab --------------------- \tab --------------------------------------------------------- \cr
-   GH Actions \tab Linux \tab no \tab no \tab \code{use_ghactions_yml("linux")}                           - \cr
-    \tab Linux \tab yes \tab no \tab \verb{use_ghactions_yml("linux-deploy)} \cr
-    \tab macOS \tab no \tab no \tab \verb{use_ghactions_yml("macos)} \cr
-    \tab macOS \tab yes \tab no \tab \verb{use_ghactions_yml("macos-deploy)} \cr
-    \tab Windows \tab no \tab no \tab \verb{use_ghactions_yml("windows)} \cr
-    \tab Windows \tab yes \tab no \tab \verb{use_ghactions_yml("windows-deploy)} \cr
-    \tab Linux + macOS \tab no \tab no \tab \code{use_ghactions_yml("linux-macos")} \cr
-    \tab Linux + macOS \tab yes \tab no \tab \code{use_ghactions_yml("linux-macos-deploy")} \cr
-    \tab Linux + Windows \tab no \tab no \tab \code{use_ghactions_yml("linux-windows")} \cr
-    \tab Linux + Windows \tab yes \tab no \tab \code{use_ghactions_yml("linux-windows-deploy")} \cr
-    \tab macOS + Windows \tab no \tab no \tab \code{use_ghactions_yml("macos-windows")} \cr
-    \tab macOS + Windows \tab yes \tab no \tab \code{use_ghactions_yml("macos-windows-deploy")} \cr
-    \tab Linux + macOS + Windows \tab no \tab no \tab \code{use_ghactions_yml("linux-macos-windows")} \cr
-    \tab Linux + macOS + Windows \tab yes \tab no \tab \code{use_ghactions_yml("linux-macos-windows-deploy")} \cr
-}
-nolint end
+Here is a list of all available combinations:
+| Provider   | Operating system         | Deployment | multiple R versions | Call                                                    |
+| -------    | ----------------         | ---------- | ------------------- | ------------------------------------------------------- |
+|----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+| Travis     | Linux                    | no         | no                  | \code{use_travis_yml("linux")}                               |
+|            | Linux                    | yes        | no                  | \code{use_travis_yml("linux-deploy")}                        |
+|            | Linux                    | no         | yes                 | \code{use_travis_yml("linux-matrix")}                        |
+|            | Linux                    | yes        | yes                 | \code{use_travis_yml("linux-deploy-matrix")}                 |
+|            | macOS                    | no         | no                  | \code{use_travis_yml("macos")}                               |
+|            | macOS                    | yes        | no                  | \code{use_travis_yml("macos-deploy")}                        |
+|            | macOS                    | no         | yes                 | \code{use_travis_yml("macos-matrix")}                        |
+|            | macOS                    | yes        | yes                 | \code{use_travis_yml("macos-deploy-matrix")}                 |
+|            | Linux + macOS            | no         | no                  | \code{use_travis_yml("linux-macos")}                         |
+|            | Linux + macOS            | yes        | no                  | \code{use_travis_yml("linux-macos-deploy")}                  |
+|            | Linux + macOS            | no         | yes                 | \code{use_travis_yml("linux-macos-matrix")}                  |
+|            | Linux + macOS            | yes        | yes                 | \code{use_travis_yml("linux-macos-deploy-matrix")}           |
+|----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+| Circle     | Linux                    | no         | no                  | \code{use_circle_yml("linux")}                               |
+|            | Linux                    | yes        | no                  | \code{use_travis_yml("linux-deploy")}                        |
+|            | Linux                    | no         | yes                 | \code{use_travis_yml("linux-matrix")}                        |
+|            | Linux                    | no         | yes                 | \code{use_travis_yml("linux-deploy-matrix")}                 |
+|----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+| Appveyor   | Windows                  | no         | no                  | \code{use_appveyor_yml("windows")}                           |
+|            | Windows                  | no         | yes                 | \code{use_travis_yml("windows-matrix")}                      |
+|----------  |------------------        |------------|---------------------|---------------------------------------------------------|
+| GH Actions | Linux                    | no         | no                  | \code{use_ghactions_yml("linux")}                           -|
+|            | Linux                    | yes        | no                  | \verb{use_ghactions_yml("linux-deploy)}                      |
+|            | macOS                    | no         | no                  | \verb{use_ghactions_yml("macos)}                             |
+|            | macOS                    | yes        | no                  | \verb{use_ghactions_yml("macos-deploy)}                      |
+|            | Windows                  | no         | no                  | \verb{use_ghactions_yml("windows)}                           |
+|            | Windows                  | yes        | no                  | \verb{use_ghactions_yml("windows-deploy)}                    |
+|            | Linux + macOS            | no         | no                  | \code{use_ghactions_yml("linux-macos")}                      |
+|            | Linux + macOS            | yes        | no                  | \code{use_ghactions_yml("linux-macos-deploy")}               |
+|            | Linux + Windows          | no         | no                  | \code{use_ghactions_yml("linux-windows")}                    |
+|            | Linux + Windows          | yes        | no                  | \code{use_ghactions_yml("linux-windows-deploy")}             |
+|            | macOS + Windows          | no         | no                  | \code{use_ghactions_yml("macos-windows")}                    |
+|            | macOS + Windows          | yes        | no                  | \code{use_ghactions_yml("macos-windows-deploy")}             |
+|            | Linux + macOS + Windows  | no         | no                  | \code{use_ghactions_yml("linux-macos-windows")}              |
+|            | Linux + macOS + Windows  | yes        | no                  | \code{use_ghactions_yml("linux-macos-windows-deploy")}       |
 }
 


### PR DESCRIPTION
This is sometimes useful, e.g. if files listed in gitignore should be force added. Defaults to `FALSE`.