### PR TITLE
Do not ignore `vignette/` if `--no-build-vignettes` was set

### DIFF
--- a/R/steps-rcmdcheck.R
+++ b/R/steps-rcmdcheck.R
@@ -36,10 +36,6 @@ RCMDcheck <- R6Class( # nolint
     },
 
     run = function() {
-      # Don't include vignettes if --no-build-vignettes is included
-      if ("--no-build-vignettes" %in% private$args) {
-        cat("^vignettes$\n", file = ".Rbuildignore", append = TRUE)
-      }
 
       withr::with_envvar(
         c(


### PR DESCRIPTION
Resolves note on Windows builds: https://github.com/krlmlr/dm/runs/709961421?check_suite_focus=true

Until now, these lines caused the following note: https://github.com/krlmlr/dm/runs/709715191?check_suite_focus=true#step:19:200

@krlmlr 
Any idea why this was added about one year ago?

This issue never came up so far because the default is `error_on = "warning"` and this note was therefore ignored on all Windows builds.
I just saw it in {dm} since `error_on = "note"` is used there.

