### PR TITLE
Make ccache optional (and more)

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -45,6 +45,7 @@ deserialize
 dev
 devtools
 dir
+dll
 dmg
 dontrun
 dsl
@@ -64,6 +65,7 @@ fxcoudert
 fxz
 Gabor
 gcc
+gdal
 GDAL
 getOption
 getRversion
@@ -85,6 +87,7 @@ init
 inits
 io
 isysroot
+javareconf
 jeroen
 Jeroen
 karthik
@@ -96,8 +99,16 @@ Krystalli
 LazyData
 libcurl
 libexec
+libgdal
+libgeos
+libglu
+libgmp
+libgs
+libproj
+libs
 LIBS
 libsodium
+libudunits
 lifecycle
 Lifecycle
 lifecyle
@@ -128,8 +139,10 @@ nCXXFLAGS
 nF
 nFC
 nhash
+nlopt
 NOHASHDIR
 nsloppiness
+NUM
 nv
 OAuth
 oldrel
@@ -139,6 +152,7 @@ Ooms
 openssl
 ORCID
 os
+osgeo
 osx
 OutFile
 packagedocs
@@ -161,6 +175,7 @@ requireNamespace
 rf
 rgl
 RGL
+rJava
 rlang
 rmacoslib
 rmarkdown
@@ -203,6 +218,8 @@ tracebacks
 travis
 ubuntu
 ucla
+udunits
+UDUNITS
 unevaluated
 usethis
 usr
@@ -214,6 +231,7 @@ WebRequest
 wget
 withr
 writeLines
+xquartz
 xz
 yaml
 YAML

--- a/inst/templates/ghactions-core.yml
+++ b/inst/templates/ghactions-core.yml
@@ -19,16 +19,10 @@
       # set date/week for use in cache creation
       # https://github.community/t5/GitHub-Actions/How-to-set-and-access-a-Workflow-variable/m-p/42970
       # - cache R packages daily
-      # - cache ccache weekly -> 'ccache' helps rebuilding the package cache faster
       - name: "[Cache] Prepare daily timestamp for cache"
         if: runner.os != 'Windows'
         id: date
         run: echo "::set-output name=date::$(date '+%d-%m')"
-
-      - name: "[Cache] Prepare weekly timestamp for cache"
-        if: runner.os != 'Windows'
-        id: datew
-        run: echo "::set-output name=datew::$(date '+%Y-%V')"
 
       - name: "[Cache] Cache R packages"
         if: runner.os != 'Windows'
@@ -37,41 +31,6 @@
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
           restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
-
-      - name: "[Cache] Cache ccache"
-        if: runner.os != 'Windows'
-        uses: pat-s/always-upload-cache@v1.2.0
-        with:
-          path: ${{ env.CCACHE_DIR}}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-
-      # install ccache and write config file
-      - name: "[Linux] ccache"
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt install ccache libcurl4-openssl-dev
-          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
-
-      # install ccache and write config file
-      # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
-      - name: "[macOS] ccache"
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: |
-          brew install ccache
-          # install SDK 10.13 (High Sierra, used by CRAN)
-          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
-          tar fxz MacOSX10.13.sdk.tar.xz
-          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
-          rm -rf MacOSX10.13*
-          # install gfortran 8.2 (used by CRAN)
-          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
-          sudo hdiutil attach gfortran*.dmg
-          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
-          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
-          rm gfortran-8*
-          # set compiler flags
-          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCXX11=ccache clang++\nCXX14=ccache clang++\nCXX17=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk -I/usr/local/include\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # for some strange Windows reason this step and the next one need to be decoupled
       - name: "[Stage] Prepare"

--- a/inst/testdata/ghactions-check-update-fail.yml
+++ b/inst/testdata/ghactions-check-update-fail.yml
@@ -1,0 +1,174 @@
+## tic GitHub Actions template: linux-macos-windows-deploy
+## revision date: 2020-05-19
+on:
+  push:
+  pull_request:
+  # for now, CRON jobs only run on the default branch of the repo (i.e. usually on master)
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 4 * * *"
+
+name: R CMD Check via {tic}
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # use a different tic template type if you do not want to build on all listed platforms
+          - { os: windows-latest, r: "release" }
+          - { os: macOS-latest, r: "release", pkgdown: "true" }
+          - { os: macOS-latest, r: "devel" }
+          - { os: ubuntu-latest, r: "release" }
+
+    env:
+      # [Custom env] DISPLAY env var for rgl package
+      DISPLAY: ":99"
+      # [Custom env] Account for udunits2 linking
+      UDUNITS2_LIBS: /usr/local/lib
+      # [Custom env] Set max dll number higher
+      R_MAX_NUM_DLLS: 999
+      # otherwise remotes::fun() errors cause the build to fail. Example: Unavailability of binaries
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      CRAN: ${{ matrix.config.cran }}
+      # we are not allowed to write to ~/.ccache on GH Actions
+      # setting some ccache options
+      CCACHE_BASEDIR: ${{ GITHUB.WORKSPACE }}
+      CCACHE_DIR: ${{ GITHUB.WORKSPACE }}/.ccache
+      CCACHE_NOHASHDIR: true
+      CCACHE_SLOPPINESS: include_file_ctime
+      # make sure to run `tic::use_ghactions_deploy()` to set up deployment
+      TIC_DEPLOY_KEY: ${{ secrets.TIC_DEPLOY_KEY }}
+      # prevent rgl issues because no X11 display is available
+      RGL_USE_NULL: true
+      # if you use bookdown or blogdown, replace "PKGDOWN" by the respective
+      # capitalized term. This also might need to be done in tic.R
+      BUILD_PKGDOWN: ${{ matrix.config.pkgdown }}
+      # macOS >= 10.15.4 linking
+      SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+      # use GITHUB_TOKEN from GitHub to workaround rate limits in {remotes}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+          Ncpus: 4
+
+      # LaTeX. Installation time:
+      # Linux: ~ 1 min
+      # macOS: ~ 1 min 30s
+      # Windows: never finishes
+      - uses: r-lib/actions/setup-tinytex@v1
+        if: runner.os != 'Windows'
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      # set date/week for use in cache creation
+      # https://github.community/t5/GitHub-Actions/How-to-set-and-access-a-Workflow-variable/m-p/42970
+      # - cache R packages daily
+      # - cache ccache weekly -> 'ccache' helps rebuilding the package cache faster
+      - name: "[Cache] Prepare daily timestamp for cache"
+        if: runner.os != 'Windows'
+        id: date
+        run: echo "::set-output name=date::$(date '+%d-%m')"
+
+      - name: "[Cache] Prepare weekly timestamp for cache"
+        if: runner.os != 'Windows'
+        id: datew
+        run: echo "::set-output name=datew::$(date '+%Y-%V')"
+
+      - name: "[Cache] Cache R packages"
+        if: runner.os != 'Windows'
+        uses: pat-s/always-upload-cache@v1.2.0
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
+
+      - name: "[Cache] Cache ccache"
+        if: runner.os != 'Windows'
+        uses: pat-s/always-upload-cache@v1.2.0
+        with:
+          path: ${{ env.CCACHE_DIR}}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
+
+      - name: "[Custom block] [Linux] Spatial libs and rJava"
+        if: runner.os == 'Linux'
+        run: |
+          sudo R CMD javareconf
+          sudo apt install -y ccache libglu1-mesa-dev libgmp-dev libgs-dev libgdal-dev libproj-dev libgeos-dev libudunits2-dev jags
+
+      # install ccache and write config file
+      - name: "[Linux] ccache"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install ccache libcurl4-openssl-dev
+          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
+
+      - name: "[Custom block] [macOS] Install additional system libs via brew"
+        if: runner.os == 'macOS'
+        run: |
+          rm '/usr/local/bin/gfortran'
+          brew tap osgeo/osgeo4mac
+          brew install udunits gdal nlopt
+          brew cask reinstall gfortran
+
+      - name: "[Custom block] [macOS] xquartz"
+        if: runner.os == 'macOS'
+        run: |
+          brew cask install xquartz
+
+      # for some strange Windows reason this step and the next one need to be decoupled
+      - name: "[Stage] Prepare"
+        run: |
+          Rscript -e "if (!requireNamespace('remotes')) install.packages('remotes', type = 'source')"
+          Rscript -e "if (getRversion() < '3.2' && !requireNamespace('curl')) install.packages('curl', type = 'source')"
+
+      - name: "[Custom block] [macOS] rJava"
+        if: runner.os == 'macOS'
+        run: |
+          R CMD javareconf
+          Rscript -e "install.packages('rJava', type = 'source')"
+
+      - name: "[Stage] Install"
+        if: matrix.config.os != 'macOS-latest' || matrix.config.r != 'devel'
+        run: Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
+
+      # macOS devel needs its own stage because we need to work with an option to suppress the usage of binaries
+      - name: "[Stage] Prepare & Install (macOS-devel)"
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'devel'
+        run: |
+          echo -e 'options(Ncpus = 4, pkgType = "source", repos = structure(c(CRAN = "https://cloud.r-project.org/")))' > $HOME/.Rprofile
+          Rscript -e "remotes::install_github('ropensci/tic')" -e "print(tic::dsl_load())" -e "tic::prepare_all_stages()" -e "tic::before_install()" -e "tic::install()"
+
+      - name: "[Stage] Script"
+        run: Rscript -e 'tic::script()'
+
+      - name: "[Stage] After Success"
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == 'release'
+        run: Rscript -e "tic::after_success()"
+
+      - name: "[Stage] Upload R CMD check artifacts"
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check
+      - name: "[Stage] Before Deploy"
+        run: |
+          Rscript -e "tic::before_deploy()"
+
+      - name: "[Stage] Deploy"
+        run: Rscript -e "tic::deploy()"
+
+      - name: "[Stage] After Deploy"
+        run: Rscript -e "tic::after_deploy()"

--- a/inst/testdata/ghactions-test-update-yaml-env-and-blocks-solution.yml
+++ b/inst/testdata/ghactions-test-update-yaml-env-and-blocks-solution.yml
@@ -75,16 +75,10 @@ jobs:
       # set date/week for use in cache creation
       # https://github.community/t5/GitHub-Actions/How-to-set-and-access-a-Workflow-variable/m-p/42970
       # - cache R packages daily
-      # - cache ccache weekly -> 'ccache' helps rebuilding the package cache faster
       - name: "[Cache] Prepare daily timestamp for cache"
         if: runner.os != 'Windows'
         id: date
         run: echo "::set-output name=date::$(date '+%d-%m')"
-
-      - name: "[Cache] Prepare weekly timestamp for cache"
-        if: runner.os != 'Windows'
-        id: datew
-        run: echo "::set-output name=datew::$(date '+%Y-%V')"
 
       - name: "[Cache] Cache R packages"
         if: runner.os != 'Windows'
@@ -94,44 +88,9 @@ jobs:
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
           restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
 
-      - name: "[Cache] Cache ccache"
-        if: runner.os != 'Windows'
-        uses: pat-s/always-upload-cache@v1.2.0
-        with:
-          path: ${{ env.CCACHE_DIR}}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-
-      # install ccache and write config file
-      - name: "[Linux] ccache"
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt install ccache libcurl4-openssl-dev
-          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
-
       - name: "[Custom block] Test custom user block"
         run: |
           echo 'test'
-
-      # install ccache and write config file
-      # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
-      - name: "[macOS] ccache"
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: |
-          brew install ccache
-          # install SDK 10.13 (High Sierra, used by CRAN)
-          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
-          tar fxz MacOSX10.13.sdk.tar.xz
-          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
-          rm -rf MacOSX10.13*
-          # install gfortran 8.2 (used by CRAN)
-          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
-          sudo hdiutil attach gfortran*.dmg
-          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
-          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
-          rm gfortran-8*
-          # set compiler flags
-          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCXX11=ccache clang++\nCXX14=ccache clang++\nCXX17=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk -I/usr/local/include\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # for some strange Windows reason this step and the next one need to be decoupled
       - name: "[Stage] Prepare"

--- a/inst/testdata/ghactions-test-update-yaml-env-and-blocks.yml
+++ b/inst/testdata/ghactions-test-update-yaml-env-and-blocks.yml
@@ -76,11 +76,6 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date '+%d-%m')"
 
-      - name: "[Cache] Prepare weekly timestamp for cache"
-        if: runner.os != 'Windows'
-        id: datew
-        run: echo "::set-output name=datew::$(date '+%Y-%V')"
-
       - name: "[Cache] Cache R packages"
         if: runner.os != 'Windows'
         uses: pat-s/always-upload-cache@v1.2.0
@@ -88,14 +83,6 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
           restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
-
-      - name: "[Cache] Cache ccache"
-        if: runner.os != 'Windows'
-        uses: pat-s/always-upload-cache@v1.2.0
-        with:
-          path: ${{ env.CCACHE_DIR}}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
 
       # install ccache and write config file
       - name: "[Linux] ccache"
@@ -107,26 +94,6 @@ jobs:
       - name: "[Custom block] Test custom user block"
         run: |
           echo 'test'
-
-      # install ccache and write config file
-      # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
-      - name: "[macOS-devel] ccache"
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
-        run: |
-          brew install ccache
-          # install SDK 10.13 (High Sierra, used by CRAN)
-          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
-          tar fxz MacOSX10.13.sdk.tar.xz
-          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
-          rm -rf MacOSX10.13*
-          # install gfortran 8.2 (used by CRAN)
-          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
-          sudo hdiutil attach gfortran*.dmg
-          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
-          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
-          rm gfortran-8*
-          # set compiler flags
-          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # for some strange Windows reason this step and the next one need to be decoupled
       - name: "[Stage] Prepare"

--- a/tests/testthat/test-update-yaml.R
+++ b/tests/testthat/test-update-yaml.R
@@ -11,6 +11,16 @@ test_that("update_yml() preserves custom env vars AND blocks", {
   expect_equal(updated, solution)
 })
 
+test_that("update_yml() fails with descriptive error message if diffs between
+          local and upstream template are too large", {
+  expect_error(
+    update_yml(
+      system.file("testdata/ghactions-check-update-fail.yml", package = "tic"), # nolint
+    ),
+    "Not enough valid anchors points found between local and upstream template."
+  )
+})
+
 # Circle CI --------------------------------------------------------------------
 
 test_that("update_yml() preserves custom env vars AND blocks", {

--- a/vignettes/ci-providers.Rmd
+++ b/vignettes/ci-providers.Rmd
@@ -61,6 +61,64 @@ If Java support is required, add the following for macOS runners:
 For Linux, add `sudo R CMD javareconf` to stage "[Linux] Prepare".
 We currently do not support Java on Windows.
 
+### ccache
+
+If you have a huge dependency chain and compiling many packages from source (especially on R-devel), `ccache` can help to speed up installation time.
+It is recommended once your dependency installation time is higher than 30 minutes.
+
+Once the `ccache` cache is build, compiled code will almost run instantly.
+Due to a default cache invalidation interval of one month, this custom action can save a lot of installation time.
+
+The downside is that `ccache` needs to be installed and configured on every run, even if it is not used (i.e. when the package cache already exists).
+This can take up to 1 min of build time.
+`ccache` won't be used on Windows since only binaries are used on this platform.
+
+You can take the following blocks and add/replace them to your `tic.yml` as needed.
+The essential part is to prefix the compiler settings in `~/.R/Makevars` with `ccache`.
+
+```yml
+      - name: "[Cache] Prepare weekly timestamp for cache"
+        if: runner.os != 'Windows'
+        id: datew
+        run: echo "::set-output name=datew::$(date '+%Y-%V')"
+        
+        
+      - name: "[Cache] Cache ccache"
+        if: runner.os != 'Windows'
+        uses: pat-s/always-upload-cache@v2.0.0
+        with:
+          path: ${{ env.CCACHE_DIR}}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-ccache-${{steps.datew.outputs.datew}}
+          
+      # install ccache and write config file
+      # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
+      - name: "[macOS] ccache"
+        if: runner.os == 'macOS' && matrix.config.r == 'devel'
+        run: |
+          brew install ccache
+          # install SDK 10.13 (High Sierra, used by CRAN)
+          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
+          tar fxz MacOSX10.13.sdk.tar.xz
+          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
+          rm -rf MacOSX10.13*
+          # install gfortran 8.2 (used by CRAN)
+          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
+          sudo hdiutil attach gfortran*.dmg
+          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
+          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
+          rm gfortran-8*
+          # set compiler flags
+          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCXX11=ccache clang++\nCXX14=ccache clang++\nCXX17=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk -I/usr/local/include\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
+
+      # install ccache and write config file
+      - name: "[Linux] ccache"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install ccache libcurl4-openssl-dev
+          mkdir -p ~/.R && echo -e 'CC=ccache gcc -std=gnu99\nCXX=ccache g++\nFC=ccache gfortran\nF77=ccache gfortran' > $HOME/.R/Makevars
+```
+
 ### Spatial libraries (gdal, proj, geos)
 
 For spatial packages on macOS, we currently recommend building against the latest GDAL and PROJ v5:

--- a/vignettes/ci-providers.Rmd
+++ b/vignettes/ci-providers.Rmd
@@ -63,27 +63,29 @@ We currently do not support Java on Windows.
 
 ### ccache
 
-If you have a huge dependency chain and compiling many packages from source (especially on R-devel), `ccache` can help to speed up installation time.
+If you have a huge dependency chain and compiling many packages from source (especially on R-devel), `ccache` can help to speed up package installation.
 It is recommended once your dependency installation time is higher than 30 minutes.
 
 Once the `ccache` cache is build, compiled code will almost run instantly.
-Due to a default cache invalidation interval of one month, this custom action can save a lot of installation time.
+The `ccache` cache itself is only invalidated once a month.
+This means package installation can make use of the cache in 29/30 days in a month.
 
-The downside is that `ccache` needs to be installed and configured on every run, even if it is not used (i.e. when the package cache already exists).
-This can take up to 1 min of build time.
-`ccache` won't be used on Windows since only binaries are used on this platform.
+The downside is that `ccache` needs to be installed and configured.
+This happens in every run, i.e. also in runs in which `ccache` is not used because a package cache already exists.
+Installation can take up to 1 min, depending on the platform.
+Note that `ccache` won't be used on Windows since only binaries are used on this platform.
 
 You can take the following blocks and add/replace them to your `tic.yml` as needed.
 The essential part is to prefix the compiler settings in `~/.R/Makevars` with `ccache`.
 
 ```yml
-      - name: "[Cache] Prepare weekly timestamp for cache"
+      - name: "[Custom] [Cache] Prepare weekly timestamp for cache"
         if: runner.os != 'Windows'
         id: datew
         run: echo "::set-output name=datew::$(date '+%Y-%V')"
         
         
-      - name: "[Cache] Cache ccache"
+      - name: "[Custom] [Cache] Cache ccache"
         if: runner.os != 'Windows'
         uses: pat-s/always-upload-cache@v2.0.0
         with:
@@ -93,26 +95,15 @@ The essential part is to prefix the compiler settings in `~/.R/Makevars` with `c
           
       # install ccache and write config file
       # mirror the setup described in https://github.com/rmacoslib/r-macos-rtools
-      - name: "[macOS] ccache"
+      - name: "[Custom] [macOS] ccache"
         if: runner.os == 'macOS' && matrix.config.r == 'devel'
         run: |
           brew install ccache
-          # install SDK 10.13 (High Sierra, used by CRAN)
-          wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
-          tar fxz MacOSX10.13.sdk.tar.xz
-          sudo mv MacOSX10.13.sdk /Library/Developer/CommandLineTools/SDKs/
-          rm -rf MacOSX10.13*
-          # install gfortran 8.2 (used by CRAN)
-          wget -nv https://github.com/fxcoudert/gfortran-for-macOS/releases/download/8.2/gfortran-8.2-Mojave.dmg
-          sudo hdiutil attach gfortran*.dmg
-          sudo installer -package /Volumes/gfortran*/gfortran*/gfortran*.pkg -target /
-          sudo hdiutil detach /Volumes/gfortran-8.2-Mojave
-          rm gfortran-8*
           # set compiler flags
-          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCXX11=ccache clang++\nCXX14=ccache clang++\nCXX17=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk -I/usr/local/include\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
+          mkdir -p ~/.R && echo -e 'CC=ccache clang\nCPP=ccache clang\nCXX=ccache clang++\nCXX11=ccache clang++\nCXX14=ccache clang++\nCXX17=ccache clang++\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nCPPFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk\nF77=ccache /usr/local/gfortran/bin/gfortran\nFC=ccache /usr/local/gfortran/bin/gfortran' > $HOME/.R/Makevars
 
       # install ccache and write config file
-      - name: "[Linux] ccache"
+      - name: "[Custom] [Linux] ccache"
         if: runner.os == 'Linux'
         run: |
           sudo apt install ccache libcurl4-openssl-dev

--- a/vignettes/ci-providers.Rmd
+++ b/vignettes/ci-providers.Rmd
@@ -66,7 +66,7 @@ We currently do not support Java on Windows.
 If you have a huge dependency chain and compiling many packages from source (especially on R-devel), `ccache` can help to speed up package installation.
 It is recommended once your dependency installation time is higher than 30 minutes.
 
-Once the `ccache` cache is build, compiled code will almost run instantly.
+Once the `ccache` cache is build, compilation will complete much faster.
 The `ccache` cache itself is only invalidated once a month.
 This means package installation can make use of the cache in 29/30 days in a month.
 


### PR DESCRIPTION
fixes #261 

This PR also

- Robustifies `update_yml()` in a way that it can now handle two `[Custom]` blocks in a row
- Removes the custom gfortran v8.2 installation on macOS (in the hope that it gets updated upstream in [homebrew cask](https://github.com/Homebrew/homebrew-cask/pull/83376) (PR issued)
- Adds instructions to vignette "ci-provider" how to add the ccache blocks again (useful for packages with many deps)
- Adds a `tryCatch()` in `update_yml()` that tells the user to update manually if the local template is too different compared to the latest upstream template (i.e. if `update_yml()` failed entirely)
- Also removes the custom installation of the 10.13 SKD to mimic CRAN behavior. Not entirely sure if this is a good idea but it bloated the YAML and things might get better over time, which we won't notice otherwise (the 10.15 SDK causes some installation errors when installing from source)