### PR TITLE
Don't install roxygen2

### DIFF
--- a/R/macro-package-checks.R
+++ b/R/macro-package-checks.R
@@ -61,8 +61,6 @@ do_package_checks <- function(...,
   #'    `warnings_are_errors`, `notes_are_errors`, `args`, and
   #'    `build_args` arguments.
   get_stage("script") %>%
-    # FIXME: Temporarily enforce roxygen dev, see https://github.com/r-lib/roxygen2/pull/1109
-    add_step(step_install_github("r-lib/roxygen2")) %>%
     add_step(
       step_rcmdcheck(
         warnings_are_errors = !!enquo(warnings_are_errors),


### PR DESCRIPTION
roxygen2 7.1.1 is on CRAN now, built for almost all platforms: https://cran.r-project.org/web/packages/roxygen2/index.html. Can we get rid of this once all binaries are ready?