### PR TITLE
Configure Git identity

### DIFF
--- a/inst/templates/ghactions-core.yml
+++ b/inst/templates/ghactions-core.yml
@@ -2,6 +2,12 @@
     steps:
       - uses: actions/checkout@v2.1.1
 
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "$GITHUB_WORKFLOW"
+          git config --global user.email "${GITHUB_EVENT_NAME}@ghactions.local"
+        shell: bash
+
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}


### PR DESCRIPTION
This seems necessary now on the macOS builds. Is this something that we should do here, or in the R code?