### PR TITLE
Correct owner and repo in CLI message of gha_add_secret()

### DIFF
--- a/R/gh-actions.R
+++ b/R/gh-actions.R
@@ -148,7 +148,7 @@ gha_add_secret <- function(secret,
   )
 
   cli::cli_alert_success("Successfully added secret {.env {name}} to repo
-   {.field {get_owner(remote)}/{get_repo(remote)}}.", wrap = TRUE)
+   {.field {owner}/{repo}}.", wrap = TRUE)
 }
 
 #' Setup deployment for GitHub Actions


### PR DESCRIPTION
If you're in a project `owner/repoA` but adding a secret to another repository with `repo_slug = "owner/repoB"`, the CLI alert message will always report having added the secret to `owner/repoA`.

Since `owner` and `repo` are already found at the start of the function, I changed the message to use those objects directly rather than calling `get_owner(remote)` etc again.