### PR TITLE
`do_pkgdown()`: Add support for pkgdown deployment for `cran-*` branches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.1.3
+    rev: v0.1.3.9014
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
@@ -37,7 +37,7 @@ repos:
     -   id: no-browser-statement
     -   id: deps-in-desc
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.0.1
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=200']

--- a/R/gh-actions.R
+++ b/R/gh-actions.R
@@ -5,9 +5,10 @@ GHActionsCI <- R6Class( # nolint
   inherit = CI,
   public = list(
     get_branch = function() {
-      ref <- Sys.getenv("GITHUB_REF")
-      # hopefully this also works for tags
-      strsplit(ref, "/", )[[1]][3]
+      # ref <- Sys.getenv("GITHUB_REF")
+      # # hopefully this also works for tags
+      # strsplit(ref, "/", )[[1]][3]
+      system("git rev-parse --abbrev-ref HEAD")
     },
     get_tag = function() {
       # FIXME: No way to get a tag? Merged with env var GITHUB_REF

--- a/R/gh-actions.R
+++ b/R/gh-actions.R
@@ -5,10 +5,14 @@ GHActionsCI <- R6Class( # nolint
   inherit = CI,
   public = list(
     get_branch = function() {
-      # ref <- Sys.getenv("GITHUB_REF")
-      # # hopefully this also works for tags
-      # strsplit(ref, "/", )[[1]][3]
-      system("git rev-parse --abbrev-ref HEAD")
+      # GITHUB_BASE_REF only exists for PRs
+      if (Sys.getenv("GITHUB_BASE_REF") != "") {
+        Sys.getenv("GITHUB_BASE_REF")
+      } else {
+        ref <- Sys.getenv("GITHUB_REF")
+        # hopefully this also works for tags
+        strsplit(ref, "/", )[[1]][3]
+      }
     },
     get_tag = function() {
       # FIXME: No way to get a tag? Merged with env var GITHUB_REF

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -61,10 +61,12 @@ do_pkgdown <- function(...,
 
     #'   2. The `branch` argument is `NULL`
     #'      (i.e., if the deployment happens to the active branch),
-    #'      or the current branch is thge default branch (usually "master")
+    #'      or the current branch is the default branch,
+    #'      or contains "cran" in its name (for compatibility with \pkg{fledge})
     #'      (see [ci_get_branch()]).
     if (deploy && !is.null(branch)) {
-      deploy <- (ci_get_branch() == github_info()$default_branch)
+      deploy <- (ci_get_branch() == github_info()$default_branch |
+        grepl("cran", ci_get_branch()))
     }
   }
 

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -68,11 +68,11 @@ do_pkgdown <- function(...,
     #'   2. The `branch` argument is `NULL`
     #'      (i.e., if the deployment happens to the active branch),
     #'      or the current branch is the default branch,
-    #'      or contains "cran" in its name (for compatibility with \pkg{fledge})
+    #'      or contains "cran-" in its name (for compatibility with \pkg{fledge})
     #'      (see [ci_get_branch()]).
     if (deploy && !is.null(branch)) {
       deploy <- (ci_get_branch() == github_info()$default_branch |
-        grepl("cran", ci_get_branch()))
+        grepl("cran-", ci_get_branch()))
       if (!deploy) {
         cli::cli_alert_info("{.field tic}: Only building pkgdown website, not
           deploying it since we are not on the default branch or a branch which

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -59,6 +59,12 @@ do_pkgdown <- function(...,
     #'      account for old default "id_rsa"
     deploy <- ci_can_push(private_key_name = private_key_name)
 
+    if (!deploy) {
+      cli::cli_alert_info("{.field tic}: Only building pkgdown website, not deploying it
+          because we are lacking push permissions to the repo. Did you add
+          a SSH key pair via {.fun tic::use_ghactions_deploy}?", wrap = TRUE)
+    }
+
     #'   2. The `branch` argument is `NULL`
     #'      (i.e., if the deployment happens to the active branch),
     #'      or the current branch is the default branch,
@@ -67,6 +73,12 @@ do_pkgdown <- function(...,
     if (deploy && !is.null(branch)) {
       deploy <- (ci_get_branch() == github_info()$default_branch |
         grepl("cran", ci_get_branch()))
+      if (!deploy) {
+        cli::cli_alert_info("{.field tic}: Only building pkgdown website, not
+          deploying it since we are not on the default branch or a branch which
+          contains 'cran' in its name but on branch
+          '{.field {tic::ci_get_branch()}}'.", wrap = TRUE)
+      }
     }
   }
 

--- a/man/do_pkgdown.Rd
+++ b/man/do_pkgdown.Rd
@@ -34,7 +34,8 @@ if the following conditions are met:
 account for old default "id_rsa"
 \item The \code{branch} argument is \code{NULL}
 (i.e., if the deployment happens to the active branch),
-or the current branch is thge default branch (usually "master")
+or the current branch is the default branch,
+or contains "cran" in its name (for compatibility with \pkg{fledge})
 (see \code{\link[=ci_get_branch]{ci_get_branch()}}).
 }}
 


### PR DESCRIPTION
and be more verbose and cat why no deployment happened (if TRUE).

To achieve this, I had to make `ci_get_branch()` conditional on whether we are in a PR or not because the current logic did not return the branch name in PRs.

Tested behavior in the recent release of {mlr3spatiotempv} today, both for a PR and default branch scenario.

fixes https://github.com/cynkra/fledge/pull/99

cc @krlmlr 