### PR TITLE
- `do_pkgdown()`: Always create a `.nojekyll` file for prod and dev deployments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.1.3.9014
+    rev: v0.2.0
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
-    -   id: roxygenize
+    # -   id: roxygenize
     # codemeta must be above use-tidy-description when both are used
     # -   id: codemeta-description-updated
     -   id: use-tidy-description

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -114,7 +114,10 @@ do_pkgdown <- function(...,
   #' 1. [step_build_pkgdown()] in the `"deploy"` stage,
   #'    forwarding all `...` arguments.
   get_stage("deploy") %>%
-    add_step(step_build_pkgdown(!!!enquos(...)))
+    add_step(step_build_pkgdown(!!!enquos(...))) %>%
+    add_code_step(writeLines("", paste0(!!path, "/.nojekyll"))) %>%
+    add_code_step(dir.create(paste0(!!path, "dev"), showWarnings = FALSE)) %>%
+    add_code_step(writeLines("", paste0(!!path, "/dev/.nojekyll")))
 
   #' 1. [step_do_push_deploy()] in the `"deploy"` stage.
   if (isTRUE(deploy)) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -194,6 +194,7 @@ nFC
 nhash
 nlopt
 NOHASHDIR
+nojekyll
 noreply
 nsloppiness
 NUM
@@ -277,6 +278,7 @@ SDKs
 seealso
 Sexpr
 SHA
+showWarnings
 SKD
 SoftwareApplication
 softwareRequirements

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -22,6 +22,7 @@ callr
 CamelCase
 ccache
 CCACHE
+Changelog
 cheatsheet
 ci
 circleci
@@ -84,6 +85,7 @@ eval
 evans
 familyName
 fansi
+faq
 fff
 fi
 figshare
@@ -119,6 +121,7 @@ harfbuzz
 hdiutil
 homebrew
 Homebrew
+href
 http
 https
 hugo
@@ -182,6 +185,7 @@ mlr
 mtime
 Müller
 mv
+navbar
 nCCFLAGS
 nCFLAGS
 nCPP
@@ -301,7 +305,9 @@ TicStep
 tidyverse
 tinytex
 tmp
+toc
 toolchain
+tooltip
 traceback
 tracebacks
 travis

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -53,6 +53,9 @@ reference:
 - title: CRAN repository functions
   contents:
   - starts_with("repo")
+- title: Helpers
+  contents:
+  - github_helpers
 - title: Deprecated
   contents:
   - Deprecated

--- a/tests/testthat/out/pkgdown.txt
+++ b/tests/testthat/out/pkgdown.txt
@@ -6,6 +6,6 @@
 ▶ step_rcmdcheck()
 ── deploy ───────────────────────────────────────────────────────────── stage ──
 ▶ step_build_pkgdown()
-▶ step_run_code(writeLines(\"\", paste0(\"docs\", \"/.nojekyll\")))"
-▶ step_run_code(dir.create(paste0(\"docs\", \"dev\"), showWarnings = FALSE))"
-▶ step_run_code(writeLines(\"\", paste0(\"docs\", \"/dev/.nojekyll\")))"
+▶ step_run_code(writeLines("", paste0("docs", "/.nojekyll")))
+▶ step_run_code(dir.create(paste0("docs", "dev"), showWarnings = FALSE))
+▶ step_run_code(writeLines("", paste0("docs", "/dev/.nojekyll")))

--- a/tests/testthat/out/pkgdown.txt
+++ b/tests/testthat/out/pkgdown.txt
@@ -6,3 +6,6 @@
 ▶ step_rcmdcheck()
 ── deploy ───────────────────────────────────────────────────────────── stage ──
 ▶ step_build_pkgdown()
+▶ step_run_code(writeLines(\"\", paste0(\"docs\", \"/.nojekyll\")))"
+▶ step_run_code(dir.create(paste0(\"docs\", \"dev\"), showWarnings = FALSE))"
+▶ step_run_code(writeLines(\"\", paste0(\"docs\", \"/dev/.nojekyll\")))"


### PR DESCRIPTION
Otherwise custom fonts which starte with an underscore in their directory name cannot be loaded as Jekyll ignores those files.

Creating a `.nojekyll` file within the site root tells GitHub pages to not build the site with the Jekyll engine which will solve the issue. 