### PR TITLE
- `do_pkgdown()`: Prevent deploying from pull requests

### DIFF
--- a/R/gh-actions.R
+++ b/R/gh-actions.R
@@ -5,14 +5,9 @@ GHActionsCI <- R6Class( # nolint
   inherit = CI,
   public = list(
     get_branch = function() {
-      # GITHUB_BASE_REF only exists for PRs
-      if (Sys.getenv("GITHUB_BASE_REF") != "") {
-        Sys.getenv("GITHUB_BASE_REF")
-      } else {
-        ref <- Sys.getenv("GITHUB_REF")
-        # hopefully this also works for tags
-        strsplit(ref, "/", )[[1]][3]
-      }
+      ref <- Sys.getenv("GITHUB_REF")
+      # hopefully this also works for tags
+      strsplit(ref, "/", )[[1]][3]
     },
     get_tag = function() {
       # FIXME: No way to get a tag? Merged with env var GITHUB_REF

--- a/R/gh-actions.R
+++ b/R/gh-actions.R
@@ -5,9 +5,14 @@ GHActionsCI <- R6Class( # nolint
   inherit = CI,
   public = list(
     get_branch = function() {
-      ref <- Sys.getenv("GITHUB_REF")
-      # hopefully this also works for tags
-      strsplit(ref, "/", )[[1]][3]
+      # only defined in PR events
+      if (Sys.getenv("GITHUB_HEAD_REF") != "") {
+        Sys.getenv("GITHUB_HEAD_REF")
+      } else {
+        ref <- Sys.getenv("GITHUB_REF")
+        # hopefully this also works for tags
+        strsplit(ref, "/", )[[1]][3]
+      }
     },
     get_tag = function() {
       # FIXME: No way to get a tag? Merged with env var GITHUB_REF

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -70,6 +70,7 @@ do_pkgdown <- function(...,
     #'      or the current branch is the default branch,
     #'      or contains "cran-" in its name (for compatibility with \pkg{fledge})
     #'      (see [ci_get_branch()]).
+    print(sprintf("DEBUG: Branch: %s, ENV_VAR: %s", ci_get_branch(), Sys.getenv("GITHUB_BASE_REF")))
     if (deploy && !is.null(branch)) {
       deploy <- (ci_get_branch() == github_info()$default_branch ||
         grepl("cran-", ci_get_branch()))

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -70,7 +70,6 @@ do_pkgdown <- function(...,
     #'      or the current branch is the default branch,
     #'      or contains "cran-" in its name (for compatibility with \pkg{fledge})
     #'      (see [ci_get_branch()]).
-    print(sprintf("DEBUG: Branch: %s, ENV_VAR: %s, MOD_ENV_VAR: %s", ci_get_branch(), Sys.getenv("GITHUB_REF"), strsplit(Sys.getenv("GITHUB_REF"), "/", )[[1]][3]))
     if (deploy && !is.null(branch)) {
       deploy <- (ci_get_branch() == github_info()$default_branch ||
         grepl("cran-", ci_get_branch()))

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -70,7 +70,7 @@ do_pkgdown <- function(...,
     #'      or the current branch is the default branch,
     #'      or contains "cran-" in its name (for compatibility with \pkg{fledge})
     #'      (see [ci_get_branch()]).
-    print(sprintf("DEBUG: Branch: %s, ENV_VAR: %s", ci_get_branch(), Sys.getenv("GITHUB_BASE_REF")))
+    print(sprintf("DEBUG: Branch: %s, ENV_VAR: %s, MOD_ENV_VAR: %s", ci_get_branch(), Sys.getenv("GITHUB_REF"), strsplit(Sys.getenv("GITHUB_REF"), "/", )[[1]][3]))
     if (deploy && !is.null(branch)) {
       deploy <- (ci_get_branch() == github_info()$default_branch ||
         grepl("cran-", ci_get_branch()))

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -71,7 +71,7 @@ do_pkgdown <- function(...,
     #'      or contains "cran-" in its name (for compatibility with \pkg{fledge})
     #'      (see [ci_get_branch()]).
     if (deploy && !is.null(branch)) {
-      deploy <- (ci_get_branch() == github_info()$default_branch |
+      deploy <- (ci_get_branch() == github_info()$default_branch ||
         grepl("cran-", ci_get_branch()))
       if (!deploy) {
         cli::cli_alert_info("{.field tic}: Only building pkgdown website, not


### PR DESCRIPTION
The old env var `GITHUB_BASE_REF` pointed to the default branch and triggered a pkgdown deployment from PRs.
The new env var `GITHUB_HEAD_REF` actually returns the branch of the PR.