### PR TITLE
- replace usethis::browse_github_pat with usethis::create_github_token

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -75,7 +75,7 @@ check_ghactions_pat <- function() {
     cli::cli_alert_danger("A {.var GITHUB_PAT} needs to be set to create
                             the SSH key pair required for deployment on GitHub
                             Actions. Please call
-                            {.fun usethis::browse_github_pat}, follow the
+                            {.fun usethis::create_github_token}, follow the
                             instructions and then call {.fun use_tic} again.",
       wrap = TRUE
     )

--- a/tic.Rproj
+++ b/tic.Rproj
@@ -17,7 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source --no-byte-compile
 PackageCheckArgs: --no-tests --as-cran --no-examples
 PackageRoxygenize: rd,collate,namespace

--- a/vignettes/deployment.Rmd
+++ b/vignettes/deployment.Rmd
@@ -41,7 +41,7 @@ A SSH key can be easily created, is safe to use and when browsing at the "Deploy
 
 To simplify the creation of a SSH key pair for deployment and adding the keys to the appropriate places, {tic} comes with a little helper function `use_ghactions_deploy()`.
 To use this function, you need a `GITHUB_PAT` with public repo scope defined in your `.Renviron`.
-`usethis::browse_github_pat()` helps setting one up if you haven't done so already.
+`usethis::create_github_token()` helps setting one up if you haven't done so already.
 
 #### Updating the deployment status
 


### PR DESCRIPTION
according to the R console warning, usethis::browse_github_pat is deprecated and should be replaced with `usethis::create_github_token` (https://usethis.r-lib.org/reference/usethis-defunct.html#browse-github-token-browse-github-pat-)